### PR TITLE
Replace Caffe2SparseToDenseProcessor with PythonSparseToDenseProcessor in tests

### DIFF
--- a/ml/rl/preprocessing/sparse_to_dense.py
+++ b/ml/rl/preprocessing/sparse_to_dense.py
@@ -5,15 +5,10 @@
 import logging
 from typing import Dict, List, Tuple
 
-import numpy as np
-
 # @manual=third-party//pandas:pandas-py
 import pandas as pd
 import torch
-from caffe2.python import workspace
-from ml.rl.caffe_utils import C2, StackedAssociativeArray
 from ml.rl.preprocessing import normalization
-from ml.rl.preprocessing.normalization import MISSING_VALUE
 
 
 logger = logging.getLogger(__name__)
@@ -28,45 +23,6 @@ class SparseToDenseProcessor:
 
     def __call__(self, sparse_data):
         return self.process(sparse_data)
-
-
-class Caffe2SparseToDenseProcessor(SparseToDenseProcessor):
-    def __init__(
-        self, sorted_features: List[int], set_missing_value_to_zero: bool = False
-    ):
-        super().__init__(sorted_features, set_missing_value_to_zero)
-
-    def process(
-        self, sparse_data: StackedAssociativeArray
-    ) -> Tuple[str, str, List[str]]:
-        lengths_blob = sparse_data.lengths
-        keys_blob = sparse_data.keys
-        values_blob = sparse_data.values
-
-        MISSING_SCALAR = C2.NextBlob("MISSING_SCALAR")
-        missing_value = 0.0 if self.set_missing_value_to_zero else MISSING_VALUE
-        workspace.FeedBlob(MISSING_SCALAR, np.array([missing_value], dtype=np.float32))
-        C2.net().GivenTensorFill([], [MISSING_SCALAR], shape=[], values=[missing_value])
-
-        parameters: List[str] = [MISSING_SCALAR]
-
-        assert len(self.sorted_features) > 0, "Sorted features is empty"
-        dense_input = C2.NextBlob("dense_input")
-        dense_input_presence = C2.NextBlob("dense_input_presence")
-        C2.net().SparseToDenseMask(
-            [keys_blob, values_blob, MISSING_SCALAR, lengths_blob],
-            [dense_input, dense_input_presence],
-            mask=self.sorted_features,
-            return_presence_mask=True,
-        )
-
-        if self.set_missing_value_to_zero:
-            dense_input_presence = C2.And(
-                C2.GT(dense_input, -1e-4, broadcast=1),
-                C2.LT(dense_input, 1e-4, broadcast=1),
-            )
-
-        return dense_input, dense_input_presence, parameters
 
 
 class PandasSparseToDenseProcessor(SparseToDenseProcessor):

--- a/ml/rl/test/gridworld/gridworld_base.py
+++ b/ml/rl/test/gridworld/gridworld_base.py
@@ -10,11 +10,9 @@ from typing import List, Tuple
 
 import numpy as np
 import torch
-from caffe2.python import core, workspace
-from ml.rl.caffe_utils import C2, StackedAssociativeArray
 from ml.rl.preprocessing.normalization import sort_features_by_normalization
 from ml.rl.preprocessing.preprocessor import Preprocessor
-from ml.rl.preprocessing.sparse_to_dense import Caffe2SparseToDenseProcessor
+from ml.rl.preprocessing.sparse_to_dense import PythonSparseToDenseProcessor
 from ml.rl.test.base.utils import default_normalizer
 from ml.rl.test.environment.environment import (
     ACTION,
@@ -70,7 +68,6 @@ class GridworldBase(Environment):
         self.reset()
         self._optimal_policy = self._compute_optimal()
         self._optimal_actions = self._compute_optimal_actions()
-        self.sparse_to_dense_net = None
         self._true_q_values = collections.defaultdict(dict)
         self._true_q_epsilon_values = collections.defaultdict(dict)
 
@@ -506,26 +503,12 @@ class GridworldBase(Environment):
 
         logger.info("Preprocessing...")
         sorted_features, _ = sort_features_by_normalization(self.normalization)
-        sparse_to_dense_processor = Caffe2SparseToDenseProcessor(sorted_features)
+        sparse_to_dense_processor = PythonSparseToDenseProcessor(sorted_features)
 
-        if self.sparse_to_dense_net is None:
-            self.sparse_to_dense_net = core.Net("gridworld_sparse_to_dense")
-            C2.set_net(self.sparse_to_dense_net)
-            saa = StackedAssociativeArray.from_dict_list(samples.states, "states")
-            self.state_matrix, self.state_matrix_presence, _ = sparse_to_dense_processor(
-                saa
-            )
-            saa = StackedAssociativeArray.from_dict_list(
-                samples.next_states, "next_states"
-            )
-            self.next_state_matrix, self.next_state_matrix_presence, _ = sparse_to_dense_processor(
-                saa
-            )
-            C2.set_net(None)
-        else:
-            StackedAssociativeArray.from_dict_list(samples.states, "states")
-            StackedAssociativeArray.from_dict_list(samples.next_states, "next_states")
-        workspace.RunNetOnce(self.sparse_to_dense_net)
+        state_matrix, state_matrix_presence = sparse_to_dense_processor(samples.states)
+        next_state_matrix, next_state_matrix_presence = sparse_to_dense_processor(
+            samples.next_states
+        )
 
         logger.info("Converting to Torch...")
         actions_one_hot = torch.tensor(
@@ -572,14 +555,10 @@ class GridworldBase(Environment):
         logger.info("Preprocessing...")
         preprocessor = Preprocessor(self.normalization, False)
 
-        states_ndarray = preprocessor(
-            torch.from_numpy(workspace.FetchBlob(self.state_matrix)),
-            torch.from_numpy(workspace.FetchBlob(self.state_matrix_presence)),
-        )
+        states_ndarray = preprocessor(state_matrix, state_matrix_presence)
 
         next_states_ndarray = preprocessor(
-            torch.from_numpy(workspace.FetchBlob(self.next_state_matrix)),
-            torch.from_numpy(workspace.FetchBlob(self.next_state_matrix_presence)),
+            next_state_matrix, next_state_matrix_presence
         )
 
         logger.info("Batching...")


### PR DESCRIPTION
Summary: Replace Caffe2SparseToDenseProcessor with PythonSparseToDenseProcessor in tests

Differential Revision: D18846423

