### PR TITLE
add terminal state to the timeline and set gym sample action random seed

### DIFF
--- a/ml/rl/test/gym/open_ai_gym_environment.py
+++ b/ml/rl/test/gym/open_ai_gym_environment.py
@@ -101,6 +101,8 @@ class OpenAIGymEnvironment(Environment):
             self.env_name = gymenv
             if random_seed is not None:
                 self.env.seed(random_seed)
+                # seed() does not set action sampling random seed properly, so we need the next line as well
+                self.env.action_space.np_random.seed(random_seed)
 
         supports_state = isinstance(self.env.observation_space, gym.spaces.Box) and len(
             self.env.observation_space.shape

--- a/ml/rl/workflow/sample_configs/discrete_action/timeline.json
+++ b/ml/rl/workflow/sample_configs/discrete_action/timeline.json
@@ -2,7 +2,7 @@
   "timeline": {
     "startDs": "2019-01-01",
     "endDs": "2019-01-01",
-    "addTerminalStateRow": false,
+    "addTerminalStateRow": true,
     "actionDiscrete": true,
     "inputTableName": "cartpole_discrete",
     "outputTableName": "cartpole_discrete_training",


### PR DESCRIPTION
When creating the timeline for gym environments, the terminal state was always set to false. I changed this parameter to ensure having terminal state. 

The other issue that this commit is solving is to make the results reproducible by properly setting the openai gym random seed.