### PR TITLE
fix CI error

### DIFF
--- a/scripts/ci/run_rasp_test.sh
+++ b/scripts/ci/run_rasp_test.sh
@@ -12,8 +12,7 @@ pip uninstall -y reagent
 pip install -e .
 
 # Clone submodules
-git submodule init
-git submodule update
+git submodule update --force --recursive --init --remote
 
 # Build RASP
 mkdir -p serving/build


### PR DESCRIPTION
See this CI error after commit d52ac7c3820b8c1bd1f1c3c864a421f481e61727: https://circleci.com/gh/facebookresearch/ReAgent/304?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Some suggested to add `git submodule sync`: https://github.com/AppImage/AppImageKit/issues/511
