### PR TITLE
Use torch.Tensor instead of np.ndarray as ReplayBuffer storage

### DIFF
--- a/reagent/gym/agents/post_step.py
+++ b/reagent/gym/agents/post_step.py
@@ -74,9 +74,7 @@ def train_with_replay_buffer_post_step(
 
         if _num_steps % training_freq == 0:
             assert replay_buffer.size >= batch_size
-            train_batch = replay_buffer.sample_transition_batch_tensor(
-                batch_size=batch_size
-            )
+            train_batch = replay_buffer.sample_transition_batch(batch_size=batch_size)
             preprocessed_batch = trainer_preprocessor(train_batch)
             trainer.train(preprocessed_batch)
         _num_steps += 1

--- a/reagent/gym/tests/preprocessors/test_replay_buffer_inserters.py
+++ b/reagent/gym/tests/preprocessors/test_replay_buffer_inserters.py
@@ -7,6 +7,7 @@ import unittest
 import gym
 import numpy as np
 import numpy.testing as npt
+import torch
 from reagent.gym.preprocessors import make_replay_buffer_inserter
 from reagent.gym.types import Transition
 from reagent.replay_memory import ReplayBuffer
@@ -65,7 +66,7 @@ class TestBasicReplayBufferInserter(HorizonTestBase):
     def test_cartpole(self):
         env = gym.make("CartPole-v0")
         replay_buffer, inserted = _create_replay_buffer_and_insert(env)
-        batch = replay_buffer.sample_transition_batch_tensor(indices=np.array([0]))
+        batch = replay_buffer.sample_transition_batch(indices=torch.tensor([0]))
         npt.assert_array_almost_equal(
             inserted[0]["observation"], batch.state.squeeze(0)
         )
@@ -88,7 +89,7 @@ class TestRecSimReplayBufferInserter(HorizonTestBase):
         }
         env = interest_evolution.create_environment(env_config)
         replay_buffer, inserted = _create_replay_buffer_and_insert(env)
-        batch = replay_buffer.sample_transition_batch_tensor(indices=np.array([0]))
+        batch = replay_buffer.sample_transition_batch(indices=torch.tensor([0]))
         npt.assert_array_almost_equal(
             inserted[0]["observation"]["user"], batch.state.squeeze(0)
         )
@@ -136,7 +137,7 @@ class TestRecSimReplayBufferInserter(HorizonTestBase):
         }
         env = interest_exploration.create_environment(env_config)
         replay_buffer, inserted = _create_replay_buffer_and_insert(env)
-        batch = replay_buffer.sample_transition_batch_tensor(indices=np.array([0]))
+        batch = replay_buffer.sample_transition_batch(indices=torch.tensor([0]))
         npt.assert_array_almost_equal(
             inserted[0]["observation"]["user"].astype(np.float32),
             batch.state.squeeze(0),

--- a/reagent/gym/tests/test_gym_offline.py
+++ b/reagent/gym/tests/test_gym_offline.py
@@ -128,7 +128,7 @@ def run_test_offline(
             logger.info(f"Evaluating before epoch {epoch}: ")
             eval_rewards = evaluate_cem(env, manager, max_steps, 1)
             for _ in tqdm(range(num_batches_per_epoch)):
-                train_batch = replay_buffer.sample_transition_batch_tensor()
+                train_batch = replay_buffer.sample_transition_batch()
                 preprocessed_batch = trainer_preprocessor(train_batch)
                 trainer.train(preprocessed_batch)
 

--- a/reagent/gym/tests/test_world_model.py
+++ b/reagent/gym/tests/test_world_model.py
@@ -136,9 +136,7 @@ def train_mdnrnn(
     logger.info("Made RBs, starting to train now!")
     for epoch in range(num_train_epochs):
         for i in range(num_batch_per_epoch):
-            batch = train_replay_buffer.sample_transition_batch_tensor(
-                batch_size=batch_size
-            )
+            batch = train_replay_buffer.sample_transition_batch(batch_size=batch_size)
             preprocessed_batch = trainer_preprocessor(batch)
             losses = trainer.train(preprocessed_batch)
             print_mdnrnn_losses(epoch, i, losses)
@@ -147,7 +145,7 @@ def train_mdnrnn(
         if test_replay_buffer is not None:
             with torch.no_grad():
                 trainer.memory_network.mdnrnn.eval()
-                test_batch = test_replay_buffer.sample_transition_batch_tensor(
+                test_batch = test_replay_buffer.sample_transition_batch(
                     batch_size=batch_size
                 )
                 preprocessed_test_batch = trainer_preprocessor(test_batch)
@@ -209,7 +207,7 @@ def train_mdnrnn_and_compute_feature_stats(
 
     with torch.no_grad():
         trainer.memory_network.mdnrnn.eval()
-        test_batch = test_replay_buffer.sample_transition_batch_tensor(
+        test_batch = test_replay_buffer.sample_transition_batch(
             batch_size=test_replay_buffer.size
         )
         preprocessed_test_batch = trainer_preprocessor(test_batch)
@@ -263,9 +261,7 @@ def create_embed_rl_dataset(
     fill_replay_buffer(
         env=embed_env, replay_buffer=embed_rb, desired_size=num_state_embed_transitions
     )
-    batch = embed_rb.sample_transition_batch_tensor(
-        batch_size=num_state_embed_transitions
-    )
+    batch = embed_rb.sample_transition_batch(batch_size=num_state_embed_transitions)
     state_min = min(batch.state.min(), batch.next_state.min()).item()
     state_max = max(batch.state.max(), batch.next_state.max()).item()
     logger.info(
@@ -359,7 +355,7 @@ def train_mdnrnn_and_train_on_embedded_env(
     num_batch_per_epoch = embed_rb.size // batch_size
     for epoch in range(num_agent_train_epochs):
         for _ in tqdm(range(num_batch_per_epoch), desc=f"epoch {epoch}"):
-            batch = embed_rb.sample_transition_batch_tensor(batch_size=batch_size)
+            batch = embed_rb.sample_transition_batch(batch_size=batch_size)
             preprocessed_batch = agent_trainer_preprocessor(batch)
             agent_trainer.train(preprocessed_batch)
 

--- a/reagent/replay_memory/circular_replay_buffer.py
+++ b/reagent/replay_memory/circular_replay_buffer.py
@@ -29,7 +29,6 @@ off-policy corrections.
 import collections
 import gzip
 import logging
-import math
 import os
 import pickle
 from typing import Dict, List, Optional, Tuple
@@ -128,7 +127,6 @@ class ReplayBuffer(object):
         max_sample_attempts: int = 1000,
         extra_storage_types: Optional[List[ReplayElement]] = None,
         observation_dtype=np.uint8,
-        terminal_dtype=np.uint8,
         action_shape: Tuple[int, ...] = (),
         action_dtype=np.int32,
         reward_shape: Tuple[int, ...] = (),
@@ -150,8 +148,6 @@ class ReplayBuffer(object):
             contents that will be stored and returned by sample_transition_batch.
           observation_dtype: np.dtype, type of the observations. Defaults to
             np.uint8 for Atari 2600.
-          terminal_dtype: np.dtype, type of the terminals. Defaults to np.uint8 for
-            Atari 2600.
           action_shape: tuple of ints, the shape for the action vector. Empty tuple
             means the action is a scalar.
           action_dtype: np.dtype, type of elements in the action.
@@ -175,7 +171,6 @@ class ReplayBuffer(object):
         )
         logger.info("\t observation_shape: %s", str(observation_shape))
         logger.info("\t observation_dtype: %s", str(observation_dtype))
-        logger.info("\t terminal_dtype: %s", str(terminal_dtype))
         logger.info("\t stack_size: %d", stack_size)
         logger.info("\t replay_capacity: %d", replay_capacity)
         logger.info("\t batch_size: %d", batch_size)
@@ -195,7 +190,7 @@ class ReplayBuffer(object):
         self._update_horizon = update_horizon
         self._gamma = gamma
         self._observation_dtype = observation_dtype
-        self._terminal_dtype = terminal_dtype
+        self._terminal_dtype = np.bool
         self._max_sample_attempts = max_sample_attempts
         if extra_storage_types:
             self._extra_storage_types = extra_storage_types
@@ -206,13 +201,11 @@ class ReplayBuffer(object):
         self.invalid_range = np.zeros((self._stack_size))
         # When the horizon is > 1, we compute the sum of discounted rewards as a dot
         # product using the precomputed vector <gamma^0, gamma^1, ..., gamma^{n-1}>.
-        self._cumulative_discount_vector = np.array(
-            [math.pow(self._gamma, n) for n in range(update_horizon)], dtype=np.float32
-        )
+        self._decays = (self._gamma ** torch.arange(self._update_horizon)).unsqueeze(0)
         # track if index is valid for sampling purposes. there're two cases
         # 1) first stack_size-1 zero transitions at start of episode
         # 2) last update_horizon transitions before the cursor
-        self._is_index_valid = np.zeros(self._replay_capacity, dtype=np.bool)
+        self._is_index_valid = torch.zeros(self._replay_capacity, dtype=torch.bool)
         self._num_valid_indices = 0
         self._num_transitions_in_current_episode = 0
         self._batch_type = collections.namedtuple(
@@ -382,11 +375,11 @@ class ReplayBuffer(object):
     def _create_storage(self) -> None:
         """Creates the numpy arrays used to store transitions.
         """
-        self._store: Dict[str, np.ndarray] = {}
+        self._store: Dict[str, torch.Tensor] = {}
         for storage_element in self.get_storage_signature():
             array_shape = [self._replay_capacity] + list(storage_element.shape)
-            self._store[storage_element.name] = np.empty(
-                array_shape, dtype=storage_element.type
+            self._store[storage_element.name] = torch.from_numpy(
+                np.empty(array_shape, dtype=storage_element.type)
             )
 
     def get_add_args_signature(self) -> List[ReplayElement]:
@@ -445,7 +438,7 @@ class ReplayBuffer(object):
         """
         self._check_add_types(observation, action, reward, terminal, *args, **kwargs)
         last_idx = (self.cursor() - 1) % self._replay_capacity
-        if self.is_empty() or self._store["terminal"][last_idx] == 1:
+        if self.is_empty() or self._store["terminal"][last_idx]:
             self._num_transitions_in_current_episode = 0
             for _ in range(self._stack_size - 1):
                 # Child classes can rely on the padding transitions being filled with
@@ -491,12 +484,23 @@ class ReplayBuffer(object):
           *args: All the elements in a transition.
         """
         self._check_args_length(*args, **kwargs)
+        elements = self.get_add_args_signature()
+        # convert kwarg np.arrays to torch.tensors
+        for element in elements[len(args) :]:
+            if element.name in kwargs:
+                kwargs[element.name] = torch.from_numpy(
+                    np.array(kwargs[element.name], dtype=element.type)
+                )
+        # convert arg np.arrays to torch.tensors
         kwargs.update(
-            {e.name: arg for arg, e in zip(args, self.get_add_args_signature())}
+            {
+                e.name: torch.from_numpy(np.array(arg, dtype=e.type))
+                for arg, e in zip(args, elements[: len(args)])
+            }
         )
         self._add_transition(kwargs)
 
-    def _add_transition(self, transition):
+    def _add_transition(self, transition: Dict[str, torch.Tensor]) -> None:
         """Internal add method to add transition dictionary to storage arrays.
         Args:
           transition: The dictionary of names and values of the transition
@@ -542,7 +546,7 @@ class ReplayBuffer(object):
                 arg_shape = np.array(arg_element).shape
             else:
                 # Assume it is scalar.
-                arg_shape = tuple()
+                arg_shape = ()
             store_element_shape = tuple(store_element.shape)
             if arg_shape != store_element_shape:
                 raise ValueError(
@@ -603,30 +607,15 @@ class ReplayBuffer(object):
             return_array = array[indices, ...]
         return return_array
 
-    def get_observation_stack(self, index):
-        return self._get_element_stack(index, "observation")
-
-    def _get_element_stack(self, index, element_name):
-        state = self.get_range(
-            self._store[element_name], index - self._stack_size + 1, index + 1
-        )
-        # The stacking axis is 0 but the agent expects as the last axis.
-        return np.moveaxis(state, 0, -1)
-
-    def get_terminal_stack(self, index):
-        return self.get_range(
-            self._store["terminal"], index - self._stack_size + 1, index + 1
-        )
-
     def is_valid_transition(self, index):
         return self._is_index_valid[index]
 
-    def sample_index_batch(self, batch_size: int):
+    def sample_index_batch(self, batch_size: int) -> torch.Tensor:
         """Returns a batch of valid indices sampled uniformly.
         Args:
           batch_size: int, number of indices returned.
         Returns:
-          list of ints, a batch of valid indices sampled uniformly.
+          1D tensor of ints, a batch of valid indices sampled uniformly.
         Raises:
           RuntimeError: If there are no valid indices to sample.
         """
@@ -634,41 +623,16 @@ class ReplayBuffer(object):
             raise RuntimeError(
                 f"Cannot sample {batch_size} since there are no valid indices so far."
             )
-        p = self._is_index_valid.astype(np.float64) / float(self._num_valid_indices)
-        indices = np.random.choice(
-            a=self._replay_capacity, size=batch_size, replace=True, p=p
-        )
-        return indices
+        valid_indices = self._is_index_valid.nonzero().squeeze(1)
+        return valid_indices[torch.randint(valid_indices.shape[0], (batch_size,))]
 
     def sample_all_valid_transitions(self):
-        nonzero = self._is_index_valid.nonzero()
+        valid_indices = self._is_index_valid.nonzero().squeeze(1)
         assert (
-            len(nonzero) == 1
-        ), f"Expecting 1-tuple since is_index_valid is one dimensional. Got {nonzero}."
-        indices = nonzero[0]
-        return self.sample_transition_batch_tensor(
-            batch_size=len(indices), indices=indices
-        )
-
-    def sample_transition_batch_tensor(self, batch_size=None, indices=None):
-        """
-        Like sample_transition_batch, but returns torch tensors. Also, reshaping to
-        our common shapes. I.e., state is 2-D unless stack_size > 1.
-        Scalar values are returned as (batch_size, 1) instead of (batch_size,)
-        """
-        batch = self.sample_transition_batch(batch_size=batch_size, indices=indices)
-
-        def _normalize_tensor(k, v):
-            squeeze_set = {"state", "next_state"}
-            t = torch.tensor(v)
-            if k in squeeze_set and self._stack_size == 1:
-                t = t.squeeze(2)
-            elif t.ndim == 1:
-                t = t.unsqueeze(1)
-            return t
-
-        return batch._replace(
-            **{k: _normalize_tensor(k, v) for k, v in batch._asdict().items()}
+            valid_indices.ndim == 1
+        ), f"Expecting 1D tensor since is_index_valid is 1D. Got {valid_indices}."
+        return self.sample_transition_batch(
+            batch_size=len(valid_indices), indices=valid_indices
         )
 
     def sample_transition_batch(self, batch_size=None, indices=None):
@@ -683,13 +647,15 @@ class ReplayBuffer(object):
         are only valid during the call to sample_transition_batch, i.e. they may
         be used by subclasses of this replay buffer but may point to different data
         as soon as sampling is done.
+        NOTE: Tensors are reshaped. I.e., state is 2-D unless stack_size > 1.
+        Scalar values are returned as (batch_size, 1) instead of (batch_size,).
         Args:
           batch_size: int, number of transitions returned. If None, the default
             batch_size will be used.
-          indices: None or list of ints, the indices of every transition in the
+          indices: None or Tensor, the indices of every transition in the
             batch. If None, sample the indices uniformly.
         Returns:
-          transition_batch: tuple of np.arrays with the shape and type as in
+          transition_batch: tuple of Tensors with the shape and type as in
             get_transition_elements().
         Raises:
           ValueError: If an element to be sampled is missing from the replay buffer.
@@ -698,100 +664,118 @@ class ReplayBuffer(object):
             batch_size = self._batch_size
         if indices is None:
             indices = self.sample_index_batch(batch_size)
-        assert isinstance(
-            indices, np.ndarray
-        ), f"Indices {indices} have type {type(indices)} instead of np.darray"
+        else:
+            assert isinstance(
+                indices, torch.Tensor
+            ), f"Indices {indices} have type {type(indices)} instead of torch.Tensor"
+            indices = indices.type(dtype=torch.int64)
         assert len(indices) == batch_size
 
         transition_elements = self.get_transition_elements(batch_size)
 
-        def get_stack_for_indices(key, indices):
-            """ Get stack of observations """
-            # calculate 2d array of indices with size (batch_size, stack_size)
-            # ith row contain indices in the stack of obs at indices[i]
-            stack_indices = indices.reshape(-1, 1) + np.arange(-self._stack_size + 1, 1)
-            stack_indices %= self._replay_capacity
-            retval = self._store[key][stack_indices]
-            if len(retval.shape) > 2:
-                # Reshape to (batch_size, obs_shape, stack_size)
-                perm = [0] + list(range(2, len(self._observation_shape) + 2)) + [1]
-                retval = retval.transpose(perm)
-            return retval
-
         # calculate 2d array of indices with size (batch_size, update_horizon)
         # ith row contain the multistep indices starting at indices[i]
-        multistep_indices = indices.reshape(-1, 1) + np.arange(self._update_horizon)
+        multistep_indices = indices.unsqueeze(1) + torch.arange(self._update_horizon)
         multistep_indices %= self._replay_capacity
 
-        def get_traj_lengths():
-            """ Calculate trajectory length, defined to be the number of states
-            in this multi_step transition until terminal state or until
-            end of multi_step (a.k.a. update_horizon).
-            """
-            terminals = self._store["terminal"][multistep_indices]
-            # if trajectory is non-terminal, we'll have traj_length = update_horizon
-            terminals[:, -1] = True
-            # Argmax find the first True in each one
-            traj_lengths = np.argmax(terminals.astype(np.bool), axis=1) + 1
-            return traj_lengths
-
-        traj_lengths = get_traj_lengths()
+        traj_lengths = self._get_traj_lengths(multistep_indices)
         next_indices = (indices + traj_lengths) % self._replay_capacity
-
-        def get_multistep_reward_for_indices():
-            """ Sums up the reward for trajectory. """
-            decays = self._gamma ** np.arange(self._update_horizon)
-            decays = decays.reshape(1, self._update_horizon)
-            masks = np.arange(self._update_horizon) < traj_lengths.reshape(-1, 1)
-            rewards = self._store["reward"][multistep_indices] * decays * masks
-            return rewards.sum(axis=1)
 
         batch_arrays = []
         for element in transition_elements:
             if element.name == "state":
-                batch = get_stack_for_indices("observation", indices)
+                batch = self._get_stack_for_indices("observation", indices)
             elif element.name == "next_state":
-                batch = get_stack_for_indices("observation", next_indices)
+                batch = self._get_stack_for_indices("observation", next_indices)
             elif element.name == "reward":
-                if self._return_everything_as_stack:
-                    if self._update_horizon > 1:
-                        raise NotImplementedError(
-                            "Uncertain how to do this without double counting.."
-                        )
-                    batch = get_stack_for_indices("reward", indices)
-                else:
-                    batch = get_multistep_reward_for_indices()
+                batch = self._get_reward_batch_for_indices(
+                    indices, multistep_indices, traj_lengths
+                )
             elif element.name == "terminal":
                 terminal_indices = (next_indices - 1) % self._replay_capacity
-                if self._return_everything_as_stack:
-                    batch = get_stack_for_indices("terminal", terminal_indices)
-                else:
-                    batch = self._store["terminal"][terminal_indices]
-                batch = batch.astype(np.bool)
+                batch = self._get_batch_for_indices(element.name, terminal_indices)
             elif element.name == "indices":
                 batch = indices
             elif element.name in self._store:
-                if self._return_everything_as_stack:
-                    batch = get_stack_for_indices(element.name, indices)
-                else:
-                    batch = self._store[element.name][indices]
+                batch = self._get_batch_for_indices(element.name, indices)
             elif element.name.startswith("next_"):
                 store_name = element.name[len("next_") :]
                 assert (
                     store_name in self._store
                 ), f"{store_name} is not in {self._store.keys()}"
-                if self._return_everything_as_stack:
-                    batch = get_stack_for_indices(store_name, next_indices)
-                else:
-                    batch = self._store[store_name][next_indices]
+                batch = self._get_batch_for_indices(store_name, next_indices)
 
-            batch = batch.astype(element.type)
+            # always enables the batch_size dim
+            if batch.ndim == 1:
+                batch = batch.unsqueeze(1)
             batch_arrays.append(batch)
 
         batch_arrays = self._batch_type(*batch_arrays)
 
         # We assume the other elements are filled in by the subclass.
         return batch_arrays
+
+    def _get_batch_for_indices(self, key: str, indices: torch.Tensor) -> torch.Tensor:
+        """ Get batch of transition data. """
+        if self._return_everything_as_stack:
+            return self._get_stack_for_indices(key, indices)
+        return self._store[key][indices]
+
+    def _get_multistep_reward_for_indices(
+        self, multistep_indices: torch.Tensor, traj_lengths: torch.Tensor
+    ) -> torch.Tensor:
+        """ Sums up the reward for trajectory. """
+
+        masks = torch.arange(self._update_horizon) < traj_lengths.unsqueeze(1)
+        rewards = self._store["reward"][multistep_indices] * self._decays * masks
+        return rewards.sum(dim=1)
+
+    def _get_reward_batch_for_indices(
+        self,
+        indices: torch.Tensor,
+        multistep_indices: torch.Tensor,
+        traj_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        """ Get batch of transition rewards. """
+        if self._return_everything_as_stack:
+            if self._update_horizon > 1:
+                raise NotImplementedError(
+                    "Uncertain how to do this without double counting.."
+                )
+            return self._get_stack_for_indices("reward", indices)
+        return self._get_multistep_reward_for_indices(multistep_indices, traj_lengths)
+
+    def _get_stack_for_indices(self, key, indices):
+        """ Get stack of transition data. """
+        # calculate 2d array of indices with size (batch_size, stack_size)
+        # ith row contain indices in the stack of obs at indices[i]
+        stack_indices = indices.unsqueeze(1) + torch.arange(-self._stack_size + 1, 1)
+        stack_indices %= self._replay_capacity
+        retval = self._store[key][stack_indices]
+        if len(retval.shape) > 2:
+            # Reshape to (batch_size, obs_shape, stack_size)
+            perm = [0] + list(range(2, len(self._observation_shape) + 2)) + [1]
+            retval = retval.permute(*perm)
+            # squeeze the stack dim if it is 1
+            if self._stack_size == 1:
+                retval = retval.squeeze(len(perm) - 1)
+        return retval
+
+    def _get_traj_lengths(self, multistep_indices: torch.Tensor) -> torch.Tensor:
+        """ Calculate trajectory length, defined to be the number of states
+        in this multi_step transition until terminal state or until
+        end of multi_step (a.k.a. update_horizon).
+        """
+        terminals = self._store["terminal"][multistep_indices]
+        # if trajectory is non-terminal, we'll have traj_length = update_horizon
+        terminals[:, -1] = True
+        # use argmax to find the first True in each trajectory
+        # NOTE: argmax may not contain the first occurrence of each maximal value found,
+        # unless it is unique, so we need to make each boolean unique,
+        # with the first occurance the largarst number
+        unique_mask = torch.arange(terminals.shape[1] + 1, 1, -1)
+        terminals = torch.einsum("ab,b->ab", (terminals, unique_mask))
+        return torch.argmax(terminals, dim=1) + 1
 
     def get_transition_elements(self, batch_size=None):
         """Returns a 'type signature' for sample_transition_batch.
@@ -863,6 +847,7 @@ class ReplayBuffer(object):
           iteration_number: int, iteration_number to use as a suffix in naming
             numpy checkpoint files.
         """
+        # TODO: Save tensors to torch files.
         if not os.path.exists(checkpoint_dir):
             return
 
@@ -878,7 +863,9 @@ class ReplayBuffer(object):
                     # self._store.
                     if attr.startswith(STORE_FILENAME_PREFIX):
                         array_name = attr[len(STORE_FILENAME_PREFIX) :]
-                        np.save(outfile, self._store[array_name], allow_pickle=False)
+                        np.save(
+                            outfile, self._store[array_name].numpy(), allow_pickle=False
+                        )
                     # Some numpy arrays might not be part of storage
                     elif isinstance(self.__dict__[attr], np.ndarray):
                         np.save(outfile, self.__dict__[attr], allow_pickle=False)
@@ -906,6 +893,7 @@ class ReplayBuffer(object):
         Raises:
           NotFoundError: If not all expected files are found in directory.
         """
+        # TODO: Load tensors from torch files.
         save_elements = self._return_checkpointable_elements()
         # We will first make sure we have all the necessary files available to avoid
         # loading a partially-specified (i.e. corrupted) replay buffer.
@@ -921,7 +909,9 @@ class ReplayBuffer(object):
                 with gzip.GzipFile(fileobj=f) as infile:
                     if attr.startswith(STORE_FILENAME_PREFIX):
                         array_name = attr[len(STORE_FILENAME_PREFIX) :]
-                        self._store[array_name] = np.load(infile, allow_pickle=False)
+                        self._store[array_name] = torch.from_numpy(
+                            np.load(infile, allow_pickle=False)
+                        )
                     elif isinstance(self.__dict__[attr], np.ndarray):
                         self.__dict__[attr] = np.load(infile, allow_pickle=False)
                     else:

--- a/reagent/replay_memory/utils.py
+++ b/reagent/replay_memory/utils.py
@@ -27,7 +27,7 @@ def replay_buffer_to_pre_timeline_df(
 ) -> pd.DataFrame:
     """ Format needed for uploading dataset to Hive, and then run timeline. """
     n = replay_buffer.size
-    batch = replay_buffer.sample_transition_batch_tensor(batch_size=n)
+    batch = replay_buffer.sample_transition_batch(batch_size=n)
 
     # actions is inconsistent between models, so let's infer them.
     possible_actions_mask = getattr(batch, "possible_actions_mask", None)

--- a/reagent/training/parametric_dqn_trainer.py
+++ b/reagent/training/parametric_dqn_trainer.py
@@ -161,7 +161,8 @@ class ParametricDQNTrainer(DQNTrainerBase):
                 training_batch.state, training_batch.action
             )
             reward_loss = F.mse_loss(
-                reward_estimates, metrics_reward_concat_real_vals.squeeze(-1)
+                reward_estimates.squeeze(-1),
+                metrics_reward_concat_real_vals.squeeze(-1),
             )
             reward_loss.backward()
             self._maybe_run_optimizer(


### PR DESCRIPTION
Summary: This diff converts the RB storage from `np.ndarray` to `torch.Tensor`. The speed profiling across these two data types can be found in [n272742](https://www.internalfb.com/intern/anp/view/?id=272742&source=bunny).

Differential Revision: D21772492

