### PR TITLE
Add iterative-softmax decoder for Seq2Slate

### DIFF
--- a/reagent/models/seq2slate_reward.py
+++ b/reagent/models/seq2slate_reward.py
@@ -7,10 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from reagent import types as rlt
-from reagent.model_utils.seq2slate_utils import (
-    DECODER_START_SYMBOL,
-    subsequent_and_padding_mask,
-)
+from reagent.model_utils.seq2slate_utils import DECODER_START_SYMBOL, subsequent_mask
 from reagent.models.base import ModelBase
 from reagent.models.seq2slate import (
     Decoder,
@@ -326,7 +323,7 @@ class Seq2SlateTransformerRewardNet(Seq2SlateRewardNetBase):
             ),
             dim=1,
         )
-        tgt_tgt_mask = subsequent_and_padding_mask(tgt_in_idx)
+        tgt_tgt_mask = subsequent_mask(tgt_seq_len + 1, device)
         # shape: batch_size, tgt_seq_len + 1, candidate_dim
         tgt_in_seq = torch.cat(
             (

--- a/reagent/net_builder/slate_ranking/slate_ranking_transformer.py
+++ b/reagent/net_builder/slate_ranking/slate_ranking_transformer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+
 from reagent.core.dataclasses import dataclass, field
+from reagent.model_utils.seq2slate_utils import Seq2SlateOutputArch
 from reagent.models.base import ModelBase
 from reagent.models.seq2slate import Seq2SlateTransformerNet
 from reagent.net_builder.slate_ranking_net_builder import SlateRankingNetBuilder
@@ -11,6 +13,8 @@ from reagent.parameters import TransformerParameters, param_hash
 class SlateRankingTransformer(SlateRankingNetBuilder):
     __hash__ = param_hash
 
+    output_arch: Seq2SlateOutputArch = Seq2SlateOutputArch.AUTOREGRESSIVE
+    temperature: float = 1.0
     transformer: TransformerParameters = field(
         default_factory=lambda: TransformerParameters(
             num_heads=2, dim_model=16, dim_feedforward=16, num_stacked_layers=2
@@ -29,5 +33,6 @@ class SlateRankingTransformer(SlateRankingNetBuilder):
             dim_feedforward=self.transformer.dim_feedforward,
             max_src_seq_len=candidate_size,
             max_tgt_seq_len=slate_size,
-            encoder_only=False,
+            output_arch=self.output_arch,
+            temperature=self.temperature,
         )

--- a/reagent/test/prediction/test_predictor_wrapper.py
+++ b/reagent/test/prediction/test_predictor_wrapper.py
@@ -6,7 +6,7 @@ import unittest
 import reagent.models as models
 import reagent.types as rlt
 import torch
-from reagent.model_utils.seq2slate_utils import Seq2SlateMode
+from reagent.model_utils.seq2slate_utils import Seq2SlateMode, Seq2SlateOutputArch
 from reagent.models.seq2slate import Seq2SlateTransformerNet
 from reagent.prediction.predictor_wrapper import (
     ActorPredictorWrapper,
@@ -184,10 +184,17 @@ class TestPredictorWrapper(unittest.TestCase):
         )
         self.assertTrue((expected_output == action).all())
 
-    def test_seq2slate_transformer_wrapper(self):
-        self._test_seq2slate_wrapper(model="transformer")
+    def test_seq2slate_transformer_frechet_sort_wrapper(self):
+        self._test_seq2slate_wrapper(
+            model="transformer", output_arch=Seq2SlateOutputArch.FRECHET_SORT
+        )
 
-    def _test_seq2slate_wrapper(self, model: str):
+    def test_seq2slate_transformer_autoregressive_wrapper(self):
+        self._test_seq2slate_wrapper(
+            model="transformer", output_arch=Seq2SlateOutputArch.AUTOREGRESSIVE
+        )
+
+    def _test_seq2slate_wrapper(self, model: str, output_arch: Seq2SlateOutputArch):
         state_normalization_parameters = {i: _cont_norm() for i in range(1, 5)}
         candidate_normalization_parameters = {i: _cont_norm() for i in range(101, 106)}
         state_preprocessor = Preprocessor(state_normalization_parameters, False)
@@ -204,7 +211,8 @@ class TestPredictorWrapper(unittest.TestCase):
                 dim_feedforward=10,
                 max_src_seq_len=10,
                 max_tgt_seq_len=4,
-                encoder_only=False,
+                output_arch=output_arch,
+                temperature=0.5,
             )
         else:
             raise NotImplementedError(f"model type {model} is unknown")

--- a/reagent/training/ranking/seq2slate_sim_trainer.py
+++ b/reagent/training/ranking/seq2slate_sim_trainer.py
@@ -91,6 +91,7 @@ class Seq2SlateSimulationTrainer(Trainer):
         baseline_optimizer: Optimizer__Union = field(  # noqa: B008
             default_factory=Optimizer__Union.default
         ),
+        policy_gradient_interval: int = 1,
         print_interval: int = 100,
     ) -> None:
         self.sim_param = parameters.simulation
@@ -100,6 +101,7 @@ class Seq2SlateSimulationTrainer(Trainer):
         self.parameters = parameters
         self.minibatch_size = minibatch_size
         self.use_gpu = use_gpu
+        self.policy_gradient_interval = policy_gradient_interval
         self.print_interval = print_interval
         self.device = torch.device("cuda") if use_gpu else torch.device("cpu")
         self.permutation_index = torch.tensor(
@@ -135,6 +137,7 @@ class Seq2SlateSimulationTrainer(Trainer):
             use_gpu=use_gpu,
             policy_optimizer=policy_optimizer,
             baseline_optimizer=baseline_optimizer,
+            policy_gradient_interval=policy_gradient_interval,
             print_interval=print_interval,
         )
         self.seq2slate_net = self.trainer.seq2slate_net

--- a/reagent/types.py
+++ b/reagent/types.py
@@ -16,10 +16,7 @@ from reagent.base_dataclass import BaseDataClass
 from reagent.core.configuration import param_hash
 from reagent.core.dataclasses import dataclass as pydantic_dataclass
 from reagent.core.fb_checker import IS_FB_ENVIRONMENT
-from reagent.model_utils.seq2slate_utils import (
-    DECODER_START_SYMBOL,
-    subsequent_and_padding_mask,
-)
+from reagent.model_utils.seq2slate_utils import DECODER_START_SYMBOL, subsequent_mask
 from reagent.preprocessing.types import InputColumn
 from reagent.torch_utils import gather
 
@@ -434,7 +431,7 @@ class PreprocessedRankingInput(TensorDataClass):
                     batch_size, output_size, candidate_dim, device=device
                 )
                 tgt_in_seq[:, 1:] = tgt_out_seq[:, :-1]
-                tgt_tgt_mask = subsequent_and_padding_mask(tgt_in_idx)
+                tgt_tgt_mask = subsequent_mask(output_size, device)
             else:
                 tgt_in_idx = None
                 tgt_out_idx = None


### PR DESCRIPTION
Summary:
We used to only have an autoregressive decoder for seq2slate. In this diff we add an iterative-softmax decoder for seq2slate. It only computes encoder scores once and then perform iterative softmax at each step until the full slate is decoded. It is equivalent to Frechet Policy Gradient mathematically.

We also add and fix more tests in the diff.

Differential Revision: D23807407

