### PR TITLE
Remove @torch.no_grad on SACTrainer.train()

### DIFF
--- a/reagent/core/observers.py
+++ b/reagent/core/observers.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional
 
 from reagent.core.tracker import Aggregator, Observer
+from reagent.tensorboardX import SummaryWriterContext
 
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,16 @@ class ValueListObserver(Observer):
 
     def reset(self):
         self.values = []
+
+
+class TensorBoardScalarObserver(Observer):
+    def __init__(self, key: str, logging_key: Optional[str]):
+        super().__init__(observing_keys=[key])
+        self.key = key
+        self.logging_key = logging_key or key
+
+    def update(self, key: str, value):
+        SummaryWriterContext.add_scalar(self.logging_key, value)
 
 
 class IntervalAggregatingObserver(Observer):

--- a/reagent/core/tracker.py
+++ b/reagent/core/tracker.py
@@ -3,7 +3,7 @@
 
 import functools
 import logging
-from typing import List
+from typing import Dict, List, Type
 
 import torch
 
@@ -41,6 +41,52 @@ class Aggregator:
         pass
 
 
+class ObservableMixin:
+    def __init__(self):
+        super().__init__()
+        self._observers = {v: [] for v in self._observable_value_types}
+
+    @property
+    def _observable_value_types(self) -> Dict[str, Type]:
+        raise NotImplementedError
+
+    def add_observer(self, observer: Observer):
+        observing_keys = observer.get_observing_keys()
+        unknown_keys = [
+            k for k in observing_keys if k not in self._observable_value_types
+        ]
+        if unknown_keys:
+            logger.warning(f"{unknown_keys} cannot be observed in {type(self)}")
+        for k in observing_keys:
+            if k in self._observers and observer not in self._observers[k]:
+                self._observers[k].append(observer)
+        return self
+
+    def add_observers(self, observers: List[Observer]):
+        for observer in observers:
+            self.add_observer(observer)
+        return self
+
+    def notify_observers(self, **kwargs):
+        for key, value in kwargs.items():
+            if value is None:
+                # Allow optional reporting
+                continue
+
+            assert key in self._observers, f"Unknown key: {key}"
+
+            # TODO: Create a generic framework for type conversion
+            if self._observable_value_types[key] == torch.Tensor:
+                if not isinstance(value, torch.Tensor):
+                    value = torch.tensor(value)
+                if len(value.shape) == 0:
+                    value = value.reshape(1)
+                value = value.detach()
+
+            for observer in self._observers[key]:
+                observer.update(key, value)
+
+
 def observable(cls=None, **kwargs):  # noqa: C901
     """
     Decorator to mark a class as producing observable values. The names of the
@@ -67,47 +113,11 @@ def observable(cls=None, **kwargs):  # noqa: C901
 
         cls.__init__ = new_init
 
-        def add_observer(self, observer: Observer) -> None:
-            observing_keys = observer.get_observing_keys()
-            unknown_keys = [
-                k for k in observing_keys if k not in self._observable_value_types
-            ]
-            if unknown_keys:
-                logger.warning(f"{unknown_keys} cannot be observed in {type(self)}")
-            for k in observing_keys:
-                if k in self._observers and observer not in self._observers[k]:
-                    self._observers[k].append(observer)
-            return self
+        cls.add_observer = ObservableMixin.add_observer
 
-        cls.add_observer = add_observer
+        cls.add_observers = ObservableMixin.add_observers
 
-        def add_observers(self, observers: List[Observer]) -> None:
-            for observer in observers:
-                self.add_observer(observer)
-            return self
-
-        cls.add_observers = add_observers
-
-        def notify_observers(self, **kwargs):
-            for key, value in kwargs.items():
-                if value is None:
-                    # Allow optional reporting
-                    continue
-
-                assert key in self._observers, f"Unknown key: {key}"
-
-                # TODO: Create a generic framework for type conversion
-                if self._observable_value_types[key] == torch.Tensor:
-                    if not isinstance(value, torch.Tensor):
-                        value = torch.tensor(value)
-                    if len(value.shape) == 0:
-                        value = value.reshape(1)
-                    value = value.detach()
-
-                for observer in self._observers[key]:
-                    observer.update(key, value)
-
-        cls.notify_observers = notify_observers
+        cls.notify_observers = ObservableMixin.notify_observers
 
         return cls
 

--- a/reagent/core/utils.py
+++ b/reagent/core/utils.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+
+class lazy_property(object):
+    """
+    More or less copy-pasta: http://stackoverflow.com/a/6849299
+    Meant to be used for lazy evaluation of an object attribute.
+    property should represent non-mutable data, as it replaces itself.
+    """
+
+    def __init__(self, fget):
+        self._fget = fget
+        self.__doc__ = fget.__doc__
+        self.__name__ = fget.__name__
+
+    def __get__(self, obj, obj_cls_type):
+        if obj is None:
+            return None
+        value = self._fget(obj)
+        setattr(obj, self.__name__, value)
+        return value

--- a/reagent/training/rl_trainer_pytorch.py
+++ b/reagent/training/rl_trainer_pytorch.py
@@ -16,7 +16,17 @@ from reagent.training.trainer import Trainer
 logger = logging.getLogger(__name__)
 
 
-class RLTrainer(Trainer):
+class RLTrainerMixin:
+    @property
+    def gamma(self):
+        return self.rl_parameters.gamma
+
+    @property
+    def tau(self):
+        return self.rl_parameters.target_update_rate
+
+
+class RLTrainer(RLTrainerMixin, Trainer):
     # Q-value for action that is not possible. Guaranteed to be worse than any
     # legitimate action
     ACTION_NOT_POSSIBLE_VAL = -1e9
@@ -32,14 +42,14 @@ class RLTrainer(Trainer):
         evaluation_parameters: Optional[EvaluationParameters] = None,
         loss_reporter=None,
     ) -> None:
+        super().__init__()
         self.minibatch = 0
         self.minibatch_size: Optional[int] = None
         self.minibatches_per_step: Optional[int] = None
         self.rl_parameters = rl_parameters
+        # TODO: Move these attributes to RLTrainerMixin?
         self.rl_temperature = float(rl_parameters.temperature)
         self.maxq_learning = rl_parameters.maxq_learning
-        self.gamma = rl_parameters.gamma
-        self.tau = rl_parameters.target_update_rate
         self.use_seq_num_diff_as_time_diff = rl_parameters.use_seq_num_diff_as_time_diff
         self.time_diff_unit_length = rl_parameters.time_diff_unit_length
         self.tensorboard_logging_freq = rl_parameters.tensorboard_logging_freq

--- a/reagent/types.py
+++ b/reagent/types.py
@@ -569,8 +569,11 @@ class BaseInput(TensorDataClass):
     step: Optional[torch.Tensor]
     not_terminal: torch.Tensor
 
-    def batch_size(self):
+    def __len__(self):
         return self.state.float_features.size()[0]
+
+    def batch_size(self):
+        return len(self)
 
     @classmethod
     def from_dict(cls, batch):
@@ -739,9 +742,6 @@ class PolicyNetworkInput(BaseInput):
             extras=batch["extras"],
         )
 
-    def batch_size(self) -> int:
-        return self.state.float_features.shape[0]
-
 
 @dataclass
 class PolicyGradientInput(TensorDataClass):
@@ -767,7 +767,7 @@ class PolicyGradientInput(TensorDataClass):
 class MemoryNetworkInput(BaseInput):
     action: torch.Tensor
 
-    def batch_size(self):
+    def __len__(self):
         if len(self.state.float_features.size()) == 2:
             return self.state.float_features.size()[0]
         elif len(self.state.float_features.size()) == 3:


### PR DESCRIPTION
Summary: ` torch.no_grad()` is not doing anything here. Removing it so that the Lightning conversion is clear.

Reviewed By: czxttkl

Differential Revision: D23946584

