### PR TITLE
Upgrade to latest Lightning logging API: reagent/training

### DIFF
--- a/reagent/training/reagent_lightning_module.py
+++ b/reagent/training/reagent_lightning_module.py
@@ -48,14 +48,12 @@ class ReAgentLightningModule(pl.LightningModule):
         """
         raise NotImplementedError
 
-    def soft_update_result(self) -> pl.TrainResult:
+    def soft_update_result(self) -> torch.Tensor:
         """
         A dummy loss to trigger soft-update
         """
         one = torch.ones(1, requires_grad=True)
-        # Create a fake graph to satisfy TrainResult
-        # pyre-fixme[16]: Module `pl` has no attribute `TrainResult`.
-        return pl.TrainResult(one + one)
+        return one + one
 
     @property
     def summary_writer(self):
@@ -115,7 +113,6 @@ class ReAgentLightningModule(pl.LightningModule):
         # Tell the trainer to stop.
         if self.current_epoch == self._next_stopping_epoch.item():
             self.trainer.should_stop = True
-        return pl.TrainResult()
 
 
 class StoppingEpochCallback(pl.Callback):

--- a/reagent/training/sac_trainer.py
+++ b/reagent/training/sac_trainer.py
@@ -310,5 +310,5 @@ class SACTrainer(RLTrainerMixin, ReAgentLightningModule):
 
         # Use the soft update rule to update the target networks
         result = self.soft_update_result()
-        result.log("td_loss", q1_loss, prog_bar=True)
+        self.log("td_loss", q1_loss, prog_bar=True)
         yield result


### PR DESCRIPTION
Summary: We are preparing fbcode for the imminent PyTorch Lightning 1.0. In 1.0, the API to log results from the LightningModule has been enhanced. Lightning is dropping support for TrainResult/EvalResult to clarify dataflow between *_step to *_epoch_end hooks vs logging via the logger. Instead of the results structs, simply use  within your LightningModule. Read the documentation for more details: https://pytorch-lightning.readthedocs.io/en/latest/loggers.html#logging-from-a-lightningmodule . Support for TrainResult/EvalResult has been discontinued as well as returning nested dictionaries that contain specific key/value pairs for logging and for progress bars. In addition, all  hooks in the LightningModule must return : these are now sinks. Use the logging API described above to log epoch end results.

Reviewed By: kittipatv

Differential Revision: D24134118

