### PR TITLE
Add value model baseline and possible action mask to REINFORCE

### DIFF
--- a/reagent/models/dqn.py
+++ b/reagent/models/dqn.py
@@ -44,9 +44,16 @@ class FullyConnectedDQN(ModelBase):
     def input_prototype(self):
         return rlt.FeatureData(self.fc.input_prototype())
 
-    def forward(self, state: rlt.FeatureData) -> torch.Tensor:
+    def forward(
+        self,
+        state: rlt.FeatureData,
+        possible_actions_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         float_features = state.float_features
         x = self.fc(float_features)
         if self.num_atoms is not None:
             x = x.view(float_features.shape[0], self.action_dim, self.num_atoms)
+        if possible_actions_mask is not None:
+            # subtract huge value from impossible actions to force their probabilities to 0
+            x -= (1 - possible_actions_mask.float()) * 1e10
         return x

--- a/reagent/net_builder/discrete_dqn/fully_connected.py
+++ b/reagent/net_builder/discrete_dqn/fully_connected.py
@@ -17,6 +17,7 @@ class FullyConnected(DiscreteDQNNetBuilder):
     sizes: List[int] = field(default_factory=lambda: [256, 128])
     activations: List[str] = field(default_factory=lambda: ["relu", "relu"])
     dropout_ratio: float = 0.0
+    use_batch_norm: bool = False
 
     def __post_init_post_parse__(self):
         super().__init__()
@@ -38,4 +39,5 @@ class FullyConnected(DiscreteDQNNetBuilder):
             sizes=self.sizes,
             activations=self.activations,
             dropout_ratio=self.dropout_ratio,
+            use_batch_norm=self.use_batch_norm,
         )

--- a/reagent/training/reinforce.py
+++ b/reagent/training/reinforce.py
@@ -3,11 +3,12 @@
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 import reagent.types as rlt
 import torch
 import torch.optim
+from reagent.models.base import ModelBase
 from reagent.optimizer.union import Optimizer__Union
 from reagent.training.trainer import Trainer
 from reagent.training.utils import discounted_returns, whiten
@@ -20,6 +21,9 @@ logger = logging.getLogger(__name__)
 class ReinforceParams:
     gamma: float = 0.0
     optimizer: Optimizer__Union = field(default_factory=Optimizer__Union.default)
+    optimizer_value_net: Optimizer__Union = field(
+        default_factory=Optimizer__Union.default
+    )
     off_policy: bool = False
     reward_clip: float = 1e6
     clip_param: float = 1e6
@@ -30,11 +34,23 @@ class ReinforceParams:
 
 
 class Reinforce(Trainer):
-    def __init__(self, actor, params: ReinforceParams):
+    def __init__(
+        self, actor, params: ReinforceParams, value_net: Optional[ModelBase] = None
+    ):
         self.scorer = actor.scorer
         self.sampler = actor.sampler
         self.params = params
         self.optimizer = params.optimizer.make_optimizer(self.scorer.parameters())
+        if value_net is not None:
+            self.value_net = value_net
+            self.value_net_optimizer = params.optimizer_value_net.make_optimizer(
+                self.value_net.parameters()
+            )
+            self.value_loss_fn = torch.nn.MSELoss(reduction="mean")
+            self.value_net_losses = []
+        else:
+            self.value_net = None
+            self.value_net_optimizer = None
         self.step = 1
         self.losses = []
 
@@ -45,11 +61,17 @@ class Reinforce(Trainer):
             loss.backward()
             del self.losses[:]
             self.optimizer.step()
+            if self.value_net_optimizer is not None:
+                self.value_net_optimizer.zero_grad()
+                value_net_loss = torch.stack(self.value_net_losses).mean()
+                value_net_loss.backward()
+                del self.value_net_losses[:]
+                self.value_net_optimizer.step()
 
     def train(self, training_batch: rlt.PolicyGradientInput) -> None:
         actions = training_batch.action
         rewards = training_batch.reward.detach()
-        scores = self.scorer(training_batch.state)
+        scores = self.scorer(training_batch.state, training_batch.possible_actions_mask)
         characteristic_eligibility = self.sampler.log_prob(scores, actions).float()
         offset_reinforcement = discounted_returns(
             torch.clamp(rewards, max=self.params.reward_clip).clone(), self.params.gamma
@@ -60,6 +82,20 @@ class Reinforce(Trainer):
             )
         if self.params.offset_clamp_min:
             offset_reinforcement = offset_reinforcement.clamp(min=0)  # pyre-ignore
+        if self.value_net is not None:
+            if self.params.normalize:
+                raise RuntimeError(
+                    "Can't apply a baseline and normalize rewards simultaneously"
+                )
+            # subtract learned value function baselines from rewards
+            baselines = self.value_net(training_batch.state).squeeze()
+            # use reward-to-go as label for training the value function
+            self.value_net_losses.append(
+                self.value_loss_fn(baselines, offset_reinforcement)
+            )
+            # detach bcs we want REINFORCE to tweak policy, not baseline
+            offset_reinforcement = offset_reinforcement - baselines.detach()
+
         if self.params.off_policy:
             target_propensity = self.sampler.log_prob(scores, actions).float()
             characteristic_eligibility = torch.exp(

--- a/reagent/types.py
+++ b/reagent/types.py
@@ -823,17 +823,20 @@ class PolicyGradientInput(TensorDataClass):
     action: torch.Tensor
     reward: torch.Tensor
     log_prob: torch.Tensor
+    possible_actions_mask: Optional[torch.Tensor] = None
 
     @classmethod
     def input_prototype(cls):
         num_classes = 5
         batch_size = 10
         state_dim = 3
+        action_dim = 2
         return cls(
             state=FeatureData(float_features=torch.randn(batch_size, state_dim)),
             action=F.one_hot(torch.randint(high=num_classes, size=(batch_size,))),
             reward=torch.rand(batch_size),
             log_prob=torch.log(torch.rand(batch_size)),
+            possible_actions_mask=torch.ones(batch_size, action_dim),
         )
 
 


### PR DESCRIPTION
Summary:
I've added:
1. Support for possible action mask in REINFORCE
2. An option to use a simple value model as a reward baseline in REINFORCE
3. An option to use Batch Norm in FC network

Reviewed By: czxttkl

Differential Revision: D24489748

