### PR TITLE
fixed typo which raised type error

### DIFF
--- a/serving/scripts/rasp_to_model.py
+++ b/serving/scripts/rasp_to_model.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.info)
+logger.setLevel(logging.INFO)
 
 
 def keys_to_int(d: Dict[str, Any]) -> Dict[int, Any]:


### PR DESCRIPTION
Fixed the typo which raised TypeError ("Level not an integer or a valid string: %r" % level) when running `python serving/scripts/rasp_to_model.py /tmp/rasp_logging/log.txt /tmp/input_df.pkl` in the RASP tutorial