### PR TITLE
Fix LR schedulers in ReAgent + supporting tests

### DIFF
--- a/reagent/optimizer/uninferrable_schedulers.py
+++ b/reagent/optimizer/uninferrable_schedulers.py
@@ -24,6 +24,7 @@ class StepLR(LearningRateSchedulerConfig):
     step_size: int
     gamma: float = 0.1
     last_epoch: int = -1
+    verbose: bool = False
 
 
 @dataclass(frozen=True)
@@ -31,12 +32,14 @@ class MultiStepLR(LearningRateSchedulerConfig):
     milestones: List[int]
     gamma: float = 0.1
     last_epoch: int = -1
+    verbose: bool = False
 
 
 @dataclass(frozen=True)
 class ExponentialLR(LearningRateSchedulerConfig):
     gamma: float
     last_epoch: int = -1
+    verbose: bool = False
 
 
 @dataclass(frozen=True)
@@ -44,6 +47,7 @@ class CosineAnnealingLR(LearningRateSchedulerConfig):
     T_max: int
     eta_min: float = 0
     last_epoch: int = -1
+    verbose: bool = False
 
 
 @dataclass(frozen=True)
@@ -60,6 +64,8 @@ class OneCycleLR(LearningRateSchedulerConfig):
     div_factor: float = 25.0
     final_div_factor: float = 10000.0
     last_epoch: int = -1
+    three_phase: bool = False
+    verbose: bool = False
 
 
 @dataclass(frozen=True)
@@ -68,3 +74,4 @@ class CosineAnnealingWarmRestarts(LearningRateSchedulerConfig):
     T_mult: int = 1
     eta_min: float = 0
     last_epoch: int = -1
+    verbose: bool = False

--- a/reagent/test/optimizer/__init__.py
+++ b/reagent/test/optimizer/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.

--- a/reagent/test/optimizer/test_make_optimizer.py
+++ b/reagent/test/optimizer/test_make_optimizer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+from reagent.optimizer.uninferrable_optimizers import Adam
+from reagent.optimizer.uninferrable_schedulers import (
+    CosineAnnealingLR,
+    CosineAnnealingWarmRestarts,
+    ExponentialLR,
+    MultiStepLR,
+    OneCycleLR,
+    StepLR,
+)
+from reagent.optimizer.utils import is_torch_lr_scheduler, is_torch_optimizer
+import torch
+import unittest
+
+
+class TestMakeOptimizer(unittest.TestCase):
+    def setUp(self):
+        self.model = torch.nn.Linear(3, 4)
+
+    def _verify_optimizer(self, optimizer):
+        self.assertTrue(is_torch_optimizer(type(optimizer.optimizer)))
+        for lr_scheduler in optimizer.lr_schedulers:
+            self.assertTrue(is_torch_lr_scheduler(type(lr_scheduler)))
+
+    def test_make_optimizer_with_step_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(
+                lr=0.001, lr_schedulers=[StepLR(gamma=0.1, step_size=0.01)]
+            ).make_optimizer(self.model.parameters())
+        )
+
+    def test_make_optimizer_with_multistep_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(
+                lr=0.001,
+                lr_schedulers=[MultiStepLR(gamma=0.2, milestones=[1000, 2000])],
+            ).make_optimizer(self.model.parameters())
+        )
+
+    def test_make_optimizer_with_exponential_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(lr=0.001, lr_schedulers=[ExponentialLR(gamma=0.9)]).make_optimizer(
+                self.model.parameters()
+            )
+        )
+
+    def test_make_optimizer_with_cosine_annealing_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(lr=0.001, lr_schedulers=[CosineAnnealingLR(T_max=1)]).make_optimizer(
+                self.model.parameters()
+            )
+        )
+
+    def test_make_optimizer_with_one_cycle_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(
+                lr=0.001,
+                lr_schedulers=[
+                    OneCycleLR(max_lr=0.1, base_momentum=0.8, total_steps=1000)
+                ],
+            ).make_optimizer(self.model.parameters())
+        )
+
+    def test_make_optimizer_with_cosine_annealing_warm_restarts_lr_scheduler(self):
+        self._verify_optimizer(
+            Adam(
+                lr=0.001, lr_schedulers=[CosineAnnealingWarmRestarts(T_0=1)]
+            ).make_optimizer(self.model.parameters())
+        )


### PR DESCRIPTION
Summary:
Fixed LR schedulers in ReAgent by adding a "verbose" field to each to match their torch.optim counterparts.

To test this, a new `optimizer_tests` target has been added to ensure that a valid Optimizer can be created for each type of LR scheduler (excluding LambdaLR, MultiplicativeLR, and CyclicLR for now as they are not supported yet).

Differential Revision: D24841422

