### PR TITLE
Migrate Seq2Slate Decoder

### DIFF
--- a/reagent/test/ranking/test_seq2slate_trainer.py
+++ b/reagent/test/ranking/test_seq2slate_trainer.py
@@ -137,12 +137,13 @@ class TestSeq2SlateTrainer(unittest.TestCase):
             net_with_gradient.named_parameters(), net_after_gradient.named_parameters()
         ):
             assert n_c == n
-            assert torch.allclose(
-                w_c - policy_gradient_interval * learning_rate * w_c.grad,
-                w,
-                rtol=1e-4,
-                atol=2e-6,
-            )
+            if w_c.grad is not None:
+                assert torch.allclose(
+                    w_c - policy_gradient_interval * learning_rate * w_c.grad,
+                    w,
+                    rtol=1e-4,
+                    atol=2e-6,
+                )
 
     def test_ips_clamp(self):
         importance_sampling = torch.tensor([0.5, 0.3, 3.0, 10.0, 40.0])

--- a/reagent/test/ranking/test_seq2slate_utils.py
+++ b/reagent/test/ranking/test_seq2slate_utils.py
@@ -53,6 +53,7 @@ def create_trainer(seq2slate_net, learning_method, batch_size, learning_rate, de
             learning_method=LearningMethod.SIMULATION,
             simulation=SimulationParameters(
                 reward_name_weight={"tour_length": 1.0},
+                reward_name_power={"tour_length": 1.0},
                 reward_name_path={"tour_length": temp_reward_model_path},
             ),
         )


### PR DESCRIPTION
Summary: Migrated Seq2Slate's Transformer-based decoder to PyTorch official implementation and fixed some issues in unit tests related to Seq2Slate.

Differential Revision: D25172983

