### PR TITLE
Fix uninferrable schedulers

### DIFF
--- a/reagent/core/registry_meta.py
+++ b/reagent/core/registry_meta.py
@@ -33,7 +33,7 @@ class RegistryMeta(abc.ABCMeta):
                 registry_name = cls.__registry_name__
                 logger.info(f"Using {registry_name} instead of {name}")
                 name = registry_name
-            assert name not in cls.REGISTRY
+            assert name not in cls.REGISTRY, f"{name} in REGISTRY {cls.REGISTRY}"
             cls.REGISTRY[name] = cls
         else:
             logger.info(

--- a/reagent/optimizer/optimizer.py
+++ b/reagent/optimizer/optimizer.py
@@ -48,7 +48,7 @@ import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.registry_meta import RegistryMeta
 
-from .scheduler_union import LearningRateScheduler__Union
+from .scheduler import LearningRateSchedulerConfig
 from .utils import is_torch_optimizer
 
 
@@ -70,7 +70,7 @@ class Optimizer:
 @dataclass(frozen=True)
 class OptimizerConfig(metaclass=RegistryMeta):
     # optional config if you want to use (potentially chained) lr scheduler
-    lr_schedulers: List[LearningRateScheduler__Union] = field(default_factory=list)
+    lr_schedulers: List[LearningRateSchedulerConfig] = field(default_factory=list)
 
     def make_optimizer(self, params) -> Optimizer:
         # Assuming the classname is the same as the torch class name

--- a/reagent/optimizer/scheduler_union.py
+++ b/reagent/optimizer/scheduler_union.py
@@ -48,7 +48,7 @@ for name in get_torch_lr_schedulers():
         torch_lr_scheduler_class = getattr(torch.optim.lr_scheduler, name)
         subclass = type(
             name,
-            # must subclass Optimizer to be added to the Registry
+            # must subclass LearningRateSchedulerConfig to be added to the Registry
             (LearningRateSchedulerConfig,),
             {"__module__": __name__},
         )
@@ -60,7 +60,4 @@ for name in get_torch_lr_schedulers():
 
 @LearningRateSchedulerConfig.fill_union()
 class LearningRateScheduler__Union(TaggedUnion):
-    def make_from_optimizer(
-        self, optimizer: torch.optim.Optimizer
-    ) -> torch.optim.lr_scheduler._LRScheduler:
-        return self.value.make_from_optimizer(optimizer)
+    pass

--- a/reagent/test/optimizer/test_make_optimizer.py
+++ b/reagent/test/optimizer/test_make_optimizer.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
+import unittest
+
+import torch
 from reagent.optimizer.uninferrable_optimizers import Adam
 from reagent.optimizer.uninferrable_schedulers import (
     CosineAnnealingLR,
@@ -11,8 +14,6 @@ from reagent.optimizer.uninferrable_schedulers import (
     StepLR,
 )
 from reagent.optimizer.utils import is_torch_lr_scheduler, is_torch_optimizer
-import torch
-import unittest
 
 
 class TestMakeOptimizer(unittest.TestCase):


### PR DESCRIPTION
Summary: While we have some uninferrable schedulers for FB internal use, we should still have counterparts for OSS.

Differential Revision: D25283564

