### PR TITLE
Fixes for DQNTrainer

### DIFF
--- a/reagent/core/tracker.py
+++ b/reagent/core/tracker.py
@@ -77,11 +77,16 @@ class ObservableMixin:
 
             # TODO: Create a generic framework for type conversion
             if self._observable_value_types[key] == torch.Tensor:
-                if not isinstance(value, torch.Tensor):
-                    value = torch.tensor(value)
-                if len(value.shape) == 0:
-                    value = value.reshape(1)
-                value = value.detach()
+                try:
+                    if not isinstance(value, torch.Tensor):
+                        value = torch.tensor(value)
+                    if len(value.shape) == 0:
+                        value = value.reshape(1)
+                    value = value.detach()
+                except Exception:
+                    # Be lenient about conversion since ReporterBase
+                    # has inaccurate type
+                    pass
 
             for observer in self._observers[key]:
                 observer.update(key, value)

--- a/reagent/gym/tests/configs/cartpole/parametric_sarsa_cartpole_online.yaml
+++ b/reagent/gym/tests/configs/cartpole/parametric_sarsa_cartpole_online.yaml
@@ -14,7 +14,6 @@ model:
         maxq_learning: false
         temperature: 0.35
       double_q_learning: true
-      minibatch_size: 1024
       minibatches_per_step: 1
       optimizer:
         Adam:
@@ -36,3 +35,4 @@ num_train_episodes: 30
 num_eval_episodes: 20
 passing_score_bar: 100.0
 use_gpu: false
+minibatch_size: 1024

--- a/reagent/gym/tests/configs/open_gridworld/discrete_dqn_open_gridworld.yaml
+++ b/reagent/gym/tests/configs/open_gridworld/discrete_dqn_open_gridworld.yaml
@@ -18,7 +18,6 @@ model:
         target_update_rate: 0.1
         maxq_learning: true
         temperature: 0.01
-        softmax_policy: true
         q_network_loss: mse
       double_q_learning: true
       minibatches_per_step: 1

--- a/reagent/parameters.py
+++ b/reagent/parameters.py
@@ -24,7 +24,7 @@ class RLParameters(BaseDataClass):
     maxq_learning: bool = True
     reward_boost: Optional[Dict[str, float]] = None
     temperature: float = 0.01
-    softmax_policy: bool = True
+    softmax_policy: bool = False
     use_seq_num_diff_as_time_diff: bool = False
     q_network_loss: str = "mse"
     set_missing_value_to_zero: bool = False

--- a/reagent/training/dqn_trainer_base.py
+++ b/reagent/training/dqn_trainer_base.py
@@ -325,12 +325,12 @@ class DQNTrainerBaseLightning(RLTrainerMixin, ReAgentLightningModule):
 
         yield metric_q_value_loss
 
-    def validation_step(self, batch, batch_idx):
+    def test_step(self, batch, batch_idx):
         return batch
 
-    def gather_eval_data(self, validation_step_outputs):
+    def gather_eval_data(self, test_step_outputs):
         eval_data = None
-        for batch in validation_step_outputs:
+        for batch in test_step_outputs:
             edp = EvaluationDataPage.create_from_training_batch(batch, self)
             if eval_data is None:
                 eval_data = edp
@@ -342,8 +342,8 @@ class DQNTrainerBaseLightning(RLTrainerMixin, ReAgentLightningModule):
             eval_data.validate()
         return eval_data
 
-    def validation_epoch_end(self, validation_step_outputs):
-        eval_data = self.gather_eval_data(validation_step_outputs)
+    def test_epoch_end(self, test_step_outputs):
+        eval_data = self.gather_eval_data(test_step_outputs)
         if eval_data.mdp_id is not None:
             cpe_details = self.evaluator.evaluate_post_training(eval_data)
             self.reporter.log(cpe_details=cpe_details)

--- a/reagent/workflow/utils.py
+++ b/reagent/workflow/utils.py
@@ -215,5 +215,5 @@ def train_eval_lightning(
         callbacks=[StoppingEpochCallback(num_epochs)],
     )
     trainer.fit(trainer_module, datamodule=datamodule)
-    # TODO: evaluate
+    trainer.test()
     return trainer


### PR DESCRIPTION
Summary:
- Evaluator should be run in `test` phrase
- The data conversion should be best effort
- When evaluating cartpole offline, we should use greedy policy

Differential Revision: D25415416

