### PR TITLE
Fixing ParametricDQNTrainer

### DIFF
--- a/reagent/gym/datasets/replay_buffer_dataset.py
+++ b/reagent/gym/datasets/replay_buffer_dataset.py
@@ -52,8 +52,9 @@ class ReplayBufferDataset(torch.utils.data.IterableDataset):
         max_steps: Optional[int] = None,
         trainer_preprocessor=None,
         replay_buffer_inserter=None,
+        device=None,
     ):
-        device = torch.device("cpu")
+        device = device or torch.device("cpu")
         if trainer_preprocessor is None:
             trainer_preprocessor = make_replay_buffer_trainer_preprocessor(
                 trainer, device, env

--- a/reagent/gym/tests/test_gym.py
+++ b/reagent/gym/tests/test_gym.py
@@ -281,7 +281,7 @@ def run_test(
 
     # pyre-fixme[16]: Module `pl` has no attribute `LightningModule`.
     if isinstance(trainer, pl.LightningModule):
-        agent = Agent.create_for_env(env, policy=training_policy)
+        agent = Agent.create_for_env(env, policy=training_policy, device=device)
         # TODO: Simplify this setup by creating LightningDataModule
         dataset = ReplayBufferDataset.create_for_trainer(
             trainer,
@@ -292,6 +292,7 @@ def run_test(
             training_frequency=train_every_ts,
             num_episodes=num_train_episodes,
             max_steps=200,
+            device=device,
         )
         data_loader = torch.utils.data.DataLoader(dataset, collate_fn=identity_collate)
         # pyre-fixme[16]: Module `pl` has no attribute `Trainer`.

--- a/reagent/training/c51_trainer.py
+++ b/reagent/training/c51_trainer.py
@@ -7,21 +7,12 @@ import reagent.types as rlt
 import torch
 from reagent.core.configuration import resolve_defaults
 from reagent.core.dataclasses import field
-from reagent.core.tracker import observable
 from reagent.optimizer import Optimizer__Union, SoftUpdate
 from reagent.parameters import RLParameters
 from reagent.training.reagent_lightning_module import ReAgentLightningModule
 from reagent.training.rl_trainer_pytorch import RLTrainerMixin, RLTrainer
 
 
-@observable(
-    td_loss=torch.Tensor,
-    logged_actions=torch.Tensor,
-    logged_propensities=torch.Tensor,
-    logged_rewards=torch.Tensor,
-    model_values=torch.Tensor,
-    model_action_idxs=torch.Tensor,
-)
 class C51Trainer(RLTrainerMixin, ReAgentLightningModule):
     """
     Implementation of 51 Categorical DQN (C51)
@@ -75,12 +66,12 @@ class C51Trainer(RLTrainerMixin, ReAgentLightningModule):
         self.qmax = qmax
         self.num_atoms = num_atoms
         self.rl_parameters = rl
-        self.support = torch.linspace(
-            self.qmin, self.qmax, self.num_atoms, device=self.device
-        )
+        self.register_buffer("support", None)
+        self.support = torch.linspace(self.qmin, self.qmax, self.num_atoms)
         self.scale_support = (self.qmax - self.qmin) / (self.num_atoms - 1.0)
 
-        self.reward_boosts = torch.zeros([1, len(self._actions)], device=self.device)
+        self.register_buffer("reward_boosts", None)
+        self.reward_boosts = torch.zeros([1, len(self._actions)])
         if self.rl_parameters.reward_boost is not None:
             # pyre-fixme[16]: Optional type has no attribute `keys`.
             for k in self.rl_parameters.reward_boost.keys():

--- a/reagent/training/dqn_trainer.py
+++ b/reagent/training/dqn_trainer.py
@@ -85,11 +85,9 @@ class DQNTrainer(DQNTrainerBaseLightning):
             reward_network, q_network_cpe, q_network_cpe_target, optimizer=optimizer
         )
 
-        self.reward_boosts = torch.nn.Parameter(
-            # pyre-fixme[6]: Expected `Sized` for 1st param but got `Optional[List[str]]`.
-            torch.zeros([1, len(self._actions)]),
-            requires_grad=False,
-        )
+        self.register_buffer("reward_boosts", None)
+        # pyre-fixme[6]: Expected `Sized` for 1st param but got `Optional[List[str]]`.
+        self.reward_boosts = torch.zeros([1, len(self._actions)])
         if rl.reward_boost is not None:
             # pyre-fixme[16]: `Optional` has no attribute `keys`.
             for k in rl.reward_boost.keys():

--- a/reagent/training/dqn_trainer_base.py
+++ b/reagent/training/dqn_trainer_base.py
@@ -12,76 +12,10 @@ from reagent.optimizer import Optimizer__Union
 from reagent.parameters import EvaluationParameters, RLParameters
 from reagent.torch_utils import masked_softmax
 from reagent.training.reagent_lightning_module import ReAgentLightningModule
-from reagent.training.rl_trainer_pytorch import RLTrainer, RLTrainerMixin
+from reagent.training.rl_trainer_pytorch import RLTrainerMixin
 
 
 logger = logging.getLogger(__name__)
-
-
-class DQNTrainerBase(RLTrainer):
-    def get_max_q_values(self, q_values, possible_actions_mask):
-        return self.get_max_q_values_with_target(
-            q_values, q_values, possible_actions_mask
-        )
-
-    def get_max_q_values_with_target(
-        self, q_values, q_values_target, possible_actions_mask
-    ):
-        """
-        Used in Q-learning update.
-
-        :param q_values: PyTorch tensor with shape (batch_size, state_dim). Each row
-            contains the list of Q-values for each possible action in this state.
-
-        :param q_values_target: PyTorch tensor with shape (batch_size, state_dim). Each row
-            contains the list of Q-values from the target network
-            for each possible action in this state.
-
-        :param possible_actions_mask: PyTorch tensor with shape (batch_size, action_dim).
-            possible_actions[i][j] = 1 iff the agent can take action j from
-            state i.
-
-        Returns a tensor of maximum Q-values for every state in the batch
-            and also the index of the corresponding action. NOTE: looks like
-            this index is only used for informational purposes only and does
-            not affect any algorithms.
-
-        """
-
-        # The parametric DQN can create flattened q values so we reshape here.
-        q_values = q_values.reshape(possible_actions_mask.shape)
-        q_values_target = q_values_target.reshape(possible_actions_mask.shape)
-        # Set q-values of impossible actions to a very large negative number.
-        inverse_pna = 1 - possible_actions_mask
-        impossible_action_penalty = self.ACTION_NOT_POSSIBLE_VAL * inverse_pna
-        q_values = q_values + impossible_action_penalty
-
-        max_q_values, max_indicies = torch.max(q_values, dim=1, keepdim=True)
-        if self.double_q_learning:
-            # Use indices of the max q_values from the online network to select q-values
-            # from the target network. This prevents overestimation of q-values.
-            # The torch.gather function selects the entry from each row that corresponds
-            # to the max_index in that row.
-            max_q_values_target = torch.gather(q_values_target, 1, max_indicies)
-        else:
-            max_q_values_target = max_q_values
-
-        return max_q_values_target, max_indicies
-
-    # pyre-fixme[56]: Decorator `torch.no_grad(...)` could not be called, because
-    #  its type `no_grad` is not callable.
-    @torch.no_grad()
-    def boost_rewards(
-        self, rewards: torch.Tensor, actions: torch.Tensor
-    ) -> torch.Tensor:
-        # Apply reward boost if specified
-        reward_boosts = torch.sum(
-            # pyre-fixme[16]: `DQNTrainerBase` has no attribute `reward_boosts`.
-            actions.float() * self.reward_boosts,
-            dim=1,
-            keepdim=True,
-        )
-        return rewards + reward_boosts
 
 
 class DQNTrainerBaseLightning(RLTrainerMixin, ReAgentLightningModule):

--- a/reagent/training/rl_trainer_pytorch.py
+++ b/reagent/training/rl_trainer_pytorch.py
@@ -16,22 +16,24 @@ from reagent.training.trainer import Trainer
 logger = logging.getLogger(__name__)
 
 
+# pyre-fixme[13]: Attribute `rl_parameters` is never initialized.
 class RLTrainerMixin:
     # todo potential inconsistencies
     _use_seq_num_diff_as_time_diff = None
     _maxq_learning = None
     _multi_steps = None
+    rl_parameters: RLParameters
 
     @property
-    def gamma(self):
+    def gamma(self) -> float:
         return self.rl_parameters.gamma
 
     @property
-    def tau(self):
+    def tau(self) -> float:
         return self.rl_parameters.target_update_rate
 
     @property
-    def multi_steps(self):
+    def multi_steps(self) -> Optional[int]:
         return (
             self.rl_parameters.multi_steps
             if self._multi_steps is None
@@ -43,7 +45,7 @@ class RLTrainerMixin:
         self._multi_steps = multi_steps
 
     @property
-    def maxq_learning(self):
+    def maxq_learning(self) -> bool:
         return (
             self.rl_parameters.maxq_learning
             if self._maxq_learning is None
@@ -55,7 +57,7 @@ class RLTrainerMixin:
         self._maxq_learning = maxq_learning
 
     @property
-    def use_seq_num_diff_as_time_diff(self):
+    def use_seq_num_diff_as_time_diff(self) -> bool:
         return (
             self.rl_parameters.use_seq_num_diff_as_time_diff
             if self._use_seq_num_diff_as_time_diff is None
@@ -65,6 +67,10 @@ class RLTrainerMixin:
     @use_seq_num_diff_as_time_diff.setter
     def use_seq_num_diff_as_time_diff(self, use_seq_num_diff_as_time_diff):
         self._use_seq_num_diff_as_time_diff = use_seq_num_diff_as_time_diff
+
+    @property
+    def rl_temperature(self) -> float:
+        return self.rl_parameters.temperature
 
 
 class RLTrainer(RLTrainerMixin, Trainer):
@@ -88,13 +94,8 @@ class RLTrainer(RLTrainerMixin, Trainer):
         self.minibatch_size: Optional[int] = None
         self.minibatches_per_step: Optional[int] = None
         self.rl_parameters = rl_parameters
-        # TODO: Move these attributes to RLTrainerMixin?
-        self.rl_temperature = float(rl_parameters.temperature)
-        self.maxq_learning = rl_parameters.maxq_learning
-        self.use_seq_num_diff_as_time_diff = rl_parameters.use_seq_num_diff_as_time_diff
         self.time_diff_unit_length = rl_parameters.time_diff_unit_length
         self.tensorboard_logging_freq = rl_parameters.tensorboard_logging_freq
-        self.multi_steps = rl_parameters.multi_steps
         self.calc_cpe_in_training = (
             evaluation_parameters and evaluation_parameters.calc_cpe_in_training
         )


### PR DESCRIPTION
Summary: ParametricDQNTrainer doesn't have Evaluator. Evaluator is only useful for discrete DQN.

Reviewed By: czxttkl

Differential Revision: D25495520

