### PR TITLE
fix: bump version of pytorch lightning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
   petastorm>=0.9.0
   parameterized>=0.7.4
   pyspark==2.4.6
-  pytorch-lightning==1.0.0rc2
+  pytorch-lightning>=1.0.0
   ruamel.yaml>=0.15.99
   scipy>=1.3.1
   tensorboard>=1.14


### PR DESCRIPTION
This PR unpins the required version of pytorch lightning and closes #364 