### PR TITLE
Fix Evaluator Bug

### DIFF
--- a/reagent/training/dqn_trainer_base.py
+++ b/reagent/training/dqn_trainer_base.py
@@ -163,12 +163,15 @@ class DQNTrainerBaseLightning(DQNTrainerMixin, RLTrainerMixin, ReAgentLightningM
         )
         self.register_buffer("reward_idx_offsets", reward_idx_offsets)
 
+        reward_stripped_metrics_to_score = (
+            self.metrics_to_score[:-1] if len(self.metrics_to_score) > 1 else None
+        )
         # pyre-fixme[16]: `DQNTrainerBase` has no attribute `evaluator`.
         self.evaluator = Evaluator(
             self._actions,
             self.rl_parameters.gamma,
-            self.trainer,
-            metrics_to_score=self.metrics_to_score,
+            self,
+            metrics_to_score=reward_stripped_metrics_to_score,
         )
 
     def _calculate_cpes(


### PR DESCRIPTION
Summary: D24698860 (https://github.com/facebookresearch/ReAgent/commit/81fc7b508b2affdec6f22908c4800a5337845b66) introduced a bug by moving the Evaluator into the DQN Trainer without adjusting the arguments. This diff corrects the arguments to make the definition consistent.

Reviewed By: czxttkl

Differential Revision: D26256281

