### PR TITLE
Add docstrings coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,8 +180,17 @@ commands:
       - store_test_results:
           path: .tox/py37/log/
 
-
-
+  run_interrogate:
+    description: Install and run interrogate
+    steps:
+      - run:
+          name: Install interrogate
+          command: |
+            pip install interrogate
+      - run:
+          name: Run interrogate on reagent code base
+          command: |
+            interrogate -piImvv -f 15 reagent/
 
 jobs:
   gpu_unittest:
@@ -290,6 +299,14 @@ jobs:
           source: https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip
       - rasp_build_test
 
+  docstring_coverage:
+    docker:
+      - image: circleci/python:3.7
+    resource_class: small
+    steps:
+      - checkout_merge
+      - run_interrogate
+
 workflows:
   build:
     jobs:
@@ -301,3 +318,4 @@ workflows:
       - gym_unittest
       - rasp_test_linux
       - rasp_test_mac
+      - docstring_coverage


### PR DESCRIPTION
Signed-off-by: Manish Pandit <manishpandit@fb.com>
<img width="1084" alt="Screen Shot 2021-02-23 at 11 06 35 AM" src="https://user-images.githubusercontent.com/7349834/108871498-37339080-75c7-11eb-9b17-a3a199d3d3d6.png">

Tested locally and it successfully performed docstrings coverage.  The current coverage is around 16% so I have set the limit to 15% to make sure that the tests pass initially.  We can increase the limits once we start improving the code.
Notes:
1. I am using circleci/python:3.7 image.
2. I am pip installing the interrogate.
