### PR TITLE
Migrate PPO trainer to Lightning

### DIFF
--- a/reagent/gym/tests/configs/cartpole/discrete_ppo_cartpole_online.yaml
+++ b/reagent/gym/tests/configs/cartpole/discrete_ppo_cartpole_online.yaml
@@ -1,0 +1,30 @@
+env:
+  Gym:
+    env_name: CartPole-v0
+model:
+  PPO:
+    trainer_param:
+      actions:
+        - 0
+        - 1
+      gamma: 0.99
+      ppo_epsilon: 0.2
+      optimizer:
+        Adam:
+          lr: 0.008
+          weight_decay: 0.001
+    policy_net_builder:
+      FullyConnected:
+        sizes:
+        - 8
+        activations:
+        - linear
+    sampler_temperature: 1.0
+num_train_episodes: 75
+num_eval_episodes: 100
+passing_score_bar: 180.0
+use_gpu: false
+dataloader_kwargs:
+  num_episodes_between_updates: 1
+  batch_size: 1
+  num_epochs: 2

--- a/reagent/notebooks/PPO_for_CartPole_Control.ipynb
+++ b/reagent/notebooks/PPO_for_CartPole_Control.ipynb
@@ -1,0 +1,591 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use the [CartPole-v1](https://gym.openai.com/envs/CartPole-v0/) OpenAI Gym environment. For reproducibility, let is fix a random seed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:43.355142Z",
+     "start_time": "2021-02-25T00:00:40.650953Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160042.161 dataclasses.py:48] USE_VANILLA_DATACLASS: True\n",
+      "I0224 160042.162 dataclasses.py:49] ARBITRARY_TYPES_ALLOWED: True\n",
+      "W0224 160042.172 file_io.py:72] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "** Please migrate to the version in iopath repo. **\n",
+      "https://github.com/facebookresearch/iopath \n",
+      "\n",
+      "W0224 160042.177 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "** Please migrate to iopath. **\n",
+      "\n",
+      "I0224 160042.178 io.py:19] Registered Manifold PathManager\n",
+      "W0224 160042.180 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "** Please migrate to iopath. **\n",
+      "\n",
+      "I0224 160042.180 patch.py:95] Patched torch.load, torch.save, torch.jit.load and save to handle Manifold uri\n",
+      "I0224 160042.333 registry_meta.py:19] Adding REGISTRY to type TrainingReport\n",
+      "I0224 160042.334 registry_meta.py:40] Not Registering TrainingReport to TrainingReport. Abstract method [] are not implemented.\n",
+      "I0224 160042.334 registry_meta.py:19] Adding REGISTRY to type PublishingResult\n",
+      "I0224 160042.335 registry_meta.py:40] Not Registering PublishingResult to PublishingResult. Abstract method [] are not implemented.\n",
+      "I0224 160042.336 registry_meta.py:19] Adding REGISTRY to type ValidationResult\n",
+      "I0224 160042.337 registry_meta.py:40] Not Registering ValidationResult to ValidationResult. Abstract method [] are not implemented.\n",
+      "I0224 160042.338 registry_meta.py:31] Registering NoPublishingResults to PublishingResult\n",
+      "I0224 160042.339 registry_meta.py:34] Using no_publishing_results instead of NoPublishingResults\n",
+      "I0224 160042.341 registry_meta.py:31] Registering NoValidationResults to ValidationResult\n",
+      "I0224 160042.341 registry_meta.py:34] Using no_validation_results instead of NoValidationResults\n",
+      "I0224 160042.347 registry_meta.py:31] Registering SchedulingFrequencyValidationResults to ValidationResult\n",
+      "I0224 160042.348 registry_meta.py:34] Using scheduling_frequency_validation_results instead of SchedulingFrequencyValidationResults\n",
+      "I0224 160042.349 registry_meta.py:31] Registering PDIVFilterValidationResults to ValidationResult\n",
+      "I0224 160042.350 registry_meta.py:34] Using pdiv_filter_validation_results instead of PDIVFilterValidationResults\n",
+      "I0224 160042.352 registry_meta.py:31] Registering Seq2SlateValidationResults to ValidationResult\n",
+      "I0224 160042.353 registry_meta.py:34] Using seq2slate_validation_results instead of Seq2SlateValidationResults\n",
+      "I0224 160042.354 registry_meta.py:31] Registering SchedulingFrequencyPublishingResults to PublishingResult\n",
+      "I0224 160042.355 registry_meta.py:34] Using scheduling_frequency_publishing_results instead of SchedulingFrequencyPublishingResults\n",
+      "I0224 160042.356 registry_meta.py:31] Registering PDIVFilterPublishingResults to PublishingResult\n",
+      "I0224 160042.356 registry_meta.py:34] Using pdiv_filter_publishing_results instead of PDIVFilterPublishingResults\n",
+      "I0224 160042.358 registry_meta.py:31] Registering FeedPublishingResults to PublishingResult\n",
+      "I0224 160042.359 registry_meta.py:34] Using feed_publishing_results instead of FeedPublishingResults\n",
+      "I0224 160042.361 registry_meta.py:31] Registering ScoreFblearnerPredictorPublishingResult to PublishingResult\n",
+      "I0224 160042.361 registry_meta.py:34] Using score_offline_results instead of ScoreFblearnerPredictorPublishingResult\n",
+      "I0224 160042.363 registry_meta.py:31] Registering ScoreSeq2SlateOutput to PublishingResult\n",
+      "I0224 160042.363 registry_meta.py:34] Using score_seq2slate_offline instead of ScoreSeq2SlateOutput\n",
+      "I0224 160042.365 registry_meta.py:31] Registering IPSResult to PublishingResult\n",
+      "I0224 160042.365 registry_meta.py:34] Using learnvm_ips_result instead of IPSResult\n",
+      "I0224 160042.367 registry_meta.py:31] Registering SlateRewardFeatureImportanceOutput to PublishingResult\n",
+      "I0224 160042.368 registry_meta.py:34] Using slate_reward_feature_importance instead of SlateRewardFeatureImportanceOutput\n",
+      "I0224 160042.372 dataclasses.py:73] Setting IdMapping.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.373 dataclasses.py:73] Setting ModelFeatureConfig.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.407 registry_meta.py:19] Adding REGISTRY to type LearningRateSchedulerConfig\n",
+      "I0224 160042.408 registry_meta.py:40] Not Registering LearningRateSchedulerConfig to LearningRateSchedulerConfig. Abstract method [] are not implemented.\n",
+      "I0224 160042.410 registry_meta.py:19] Adding REGISTRY to type OptimizerConfig\n",
+      "I0224 160042.410 registry_meta.py:40] Not Registering OptimizerConfig to OptimizerConfig. Abstract method [] are not implemented.\n",
+      "I0224 160042.411 registry_meta.py:31] Registering Adam to OptimizerConfig\n",
+      "I0224 160042.413 registry_meta.py:31] Registering SGD to OptimizerConfig\n",
+      "I0224 160042.414 registry_meta.py:31] Registering AdamW to OptimizerConfig\n",
+      "I0224 160042.416 registry_meta.py:31] Registering SparseAdam to OptimizerConfig\n",
+      "I0224 160042.418 registry_meta.py:31] Registering Adamax to OptimizerConfig\n",
+      "I0224 160042.419 registry_meta.py:31] Registering LBFGS to OptimizerConfig\n",
+      "I0224 160042.421 registry_meta.py:31] Registering Rprop to OptimizerConfig\n",
+      "I0224 160042.423 registry_meta.py:31] Registering ASGD to OptimizerConfig\n",
+      "I0224 160042.424 registry_meta.py:31] Registering Adadelta to OptimizerConfig\n",
+      "I0224 160042.426 registry_meta.py:31] Registering Adagrad to OptimizerConfig\n",
+      "I0224 160042.427 registry_meta.py:31] Registering RMSprop to OptimizerConfig\n",
+      "I0224 160042.449 dataclasses.py:73] Setting Seq2SlateNet.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.468 dataclasses.py:73] Setting CRRWeightFn.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.489 registry_meta.py:19] Adding REGISTRY to type EnvWrapper\n",
+      "I0224 160042.490 registry_meta.py:40] Not Registering EnvWrapper to EnvWrapper. Abstract method ['serving_obs_preprocessor', 'make', 'obs_preprocessor'] are not implemented.\n",
+      "I0224 160042.490 dataclasses.py:73] Setting EnvWrapper.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.496 registry_meta.py:31] Registering ChangingArms to EnvWrapper\n",
+      "I0224 160042.513 registry_meta.py:31] Registering Gym to EnvWrapper\n",
+      "I0224 160042.517 utils.py:18] Registering id=Pocman-v0, entry_point=reagent.gym.envs.pomdp.pocman:PocManEnv.\n",
+      "I0224 160042.518 utils.py:18] Registering id=StringGame-v0, entry_point=reagent.gym.envs.pomdp.string_game:StringGameEnv.\n",
+      "I0224 160042.519 utils.py:18] Registering id=LinearDynamics-v0, entry_point=reagent.gym.envs.dynamics.linear_dynamics:LinDynaEnv.\n",
+      "I0224 160042.519 utils.py:18] Registering id=PossibleActionsMaskTester-v0, entry_point=reagent.gym.envs.functionality.possible_actions_mask_tester:PossibleActionsMaskTester.\n",
+      "I0224 160042.520 utils.py:18] Registering id=StringGame-v1, entry_point=reagent.gym.envs.pomdp.string_game_v1:StringGameEnvV1.\n",
+      "I0224 160042.551 registry_meta.py:31] Registering RecSim to EnvWrapper\n",
+      "I0224 160042.552 dataclasses.py:73] Setting RecSim.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.555 registry_meta.py:31] Registering OraclePVM to EnvWrapper\n",
+      "I0224 160042.556 dataclasses.py:73] Setting OraclePVM.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160042.565 registry_meta.py:31] Registering ToyVM to EnvWrapper\n",
+      "\n",
+      "Bad key \"axes.color_cycle\" on line 214 in\n",
+      "/home/alexnik/.matplotlib/matplotlibrc.\n",
+      "You probably need to get an updated matplotlibrc file from\n",
+      "https://github.com/matplotlib/matplotlib/blob/v3.1.2/matplotlibrc.template\n",
+      "or from the matplotlib source distribution\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pytorch_lightning as pl\n",
+    "from reagent.gym.envs.gym import Gym\n",
+    "import pandas as pd\n",
+    "from matplotlib import pyplot as plt\n",
+    "import seaborn as sns\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "import tqdm.autonotebook as tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:43.533034Z",
+     "start_time": "2021-02-25T00:00:43.357339Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160043.363 env_wrapper.py:38] Env: <TimeLimit<CartPoleEnv<CartPole-v0>>>;\n",
+      "observation_space: Box(4,);\n",
+      "action_space: Discrete(2);\n",
+      "I0224 160043.365 seed.py:57] Global seed set to 0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {
+      "bento_obj_id": "139979157612704"
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "env = Gym('CartPole-v0')\n",
+    "env.seed(0)\n",
+    "env.action_space.seed(0)\n",
+    "pl.seed_everything(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `policy` is composed of a simple scorer (a MLP) and a softmax sampler. Our `agent` simply executes this policy in the CartPole Environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:43.817285Z",
+     "start_time": "2021-02-25T00:00:43.535633Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160043.644 registry_meta.py:19] Adding REGISTRY to type DiscreteDQNNetBuilder\n",
+      "I0224 160043.645 registry_meta.py:40] Not Registering DiscreteDQNNetBuilder to DiscreteDQNNetBuilder. Abstract method ['build_q_network'] are not implemented.\n",
+      "I0224 160043.645 registry_meta.py:31] Registering Dueling to DiscreteDQNNetBuilder\n",
+      "I0224 160043.646 dataclasses.py:73] Setting Dueling.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160043.648 registry_meta.py:31] Registering FullyConnected to DiscreteDQNNetBuilder\n",
+      "I0224 160043.649 dataclasses.py:73] Setting FullyConnected.__post_init__ to its __post_init_post_parse__\n",
+      "I0224 160043.651 registry_meta.py:31] Registering FullyConnectedWithEmbedding to DiscreteDQNNetBuilder\n",
+      "I0224 160043.651 dataclasses.py:73] Setting FullyConnectedWithEmbedding.__post_init__ to its __post_init_post_parse__\n"
+     ]
+    }
+   ],
+   "source": [
+    "from reagent.net_builder.discrete_dqn.fully_connected import FullyConnected\n",
+    "from reagent.gym.utils import build_normalizer\n",
+    "\n",
+    "norm = build_normalizer(env)\n",
+    "net_builder = FullyConnected(sizes=[8], activations=[\"linear\"])\n",
+    "cartpole_scorer = net_builder.build_q_network(\n",
+    "    state_feature_config=None, \n",
+    "    state_normalization_data=norm['state'],\n",
+    "    output_dim=len(norm['action'].dense_normalization_parameters))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:43.994904Z",
+     "start_time": "2021-02-25T00:00:43.820165Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from reagent.gym.policies.policy import Policy\n",
+    "from reagent.gym.policies.samplers.discrete_sampler import SoftmaxActionSampler\n",
+    "from reagent.gym.agents.agent import Agent\n",
+    "\n",
+    "\n",
+    "policy = Policy(scorer=cartpole_scorer, sampler=SoftmaxActionSampler())\n",
+    "agent = Agent.create_for_env(env, policy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a trainer that uses the PPO Algorithm to train."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:44.180279Z",
+     "start_time": "2021-02-25T00:00:43.997244Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from reagent.training.ppo_trainer import PPOTrainer\n",
+    "from reagent.optimizer.union import classes\n",
+    "\n",
+    "\n",
+    "ppo_trainer = PPOTrainer(\n",
+    "    policy=policy,\n",
+    "    gamma=0.99,\n",
+    "    optimizer=classes['Adam'](lr=8e-3, weight_decay=1e-3),\n",
+    "    ppo_epsilon=0.2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RL Interaction Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:48.623567Z",
+     "start_time": "2021-02-25T00:00:44.182376Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160046.344 gymrunner.py:132] For gamma=1.0, average reward is 18.6\n",
+      "Rewards list: [15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18.\n",
+      " 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18.\n",
+      " 15. 18. 15. 18. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12.\n",
+      " 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12.\n",
+      " 29. 12. 29. 12. 29. 12. 29. 12. 17. 21. 17. 21. 17. 21. 17. 21. 17. 21.\n",
+      " 17. 21. 17. 21. 17. 21. 17. 21. 17. 21.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from reagent.gym.runners.gymrunner import evaluate_for_n_episodes\n",
+    "eval_rewards = evaluate_for_n_episodes(100, env, agent, 500, num_processes=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run training loop (managed by Pytorch Lightning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:48.807351Z",
+     "start_time": "2021-02-25T00:00:48.626018Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160048.628 seed.py:57] Global seed set to 0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {
+      "bento_obj_id": "139979157612704"
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pl.seed_everything(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:48.982293Z",
+     "start_time": "2021-02-25T00:00:48.809528Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "num_episodes = 75\n",
+    "max_steps = 200\n",
+    "reward_decay = 0.8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:00:49.170773Z",
+     "start_time": "2021-02-25T00:00:48.985979Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160049.000 distributed.py:54] GPU available: False, used: False\n",
+      "I0224 160049.001 distributed.py:54] TPU available: None, using: 0 TPU cores\n"
+     ]
+    }
+   ],
+   "source": [
+    "from reagent.gym.datasets.episodic_dataset import EpisodicDataset, EpisodicDatasetDataloader\n",
+    "\n",
+    "pl_trainer = pl.Trainer(max_epochs=1, deterministic=True)\n",
+    "dataset = EpisodicDataset(env=env, agent=agent, num_episodes=num_episodes, seed=0, max_steps=max_steps)\n",
+    "\n",
+    "train_rewards = []\n",
+    "class TrainRewardsExtractor(EpisodicDataset):\n",
+    "    # a wrapper around a dataset to enable logging of rewards during training\n",
+    "    def __init__(self, dataset):\n",
+    "        self.dataset = dataset\n",
+    "        \n",
+    "    def __iter__(self):\n",
+    "        for traj in iter(self.dataset):\n",
+    "            ep_reward = traj[\"reward\"].sum().item()\n",
+    "            train_rewards.append(ep_reward)\n",
+    "            yield traj\n",
+    "            \n",
+    "    def __getattr__(self, name):\n",
+    "        return getattr(self.dataset, name)\n",
+    "    \n",
+    "dataset = TrainRewardsExtractor(dataset)\n",
+    "\n",
+    "dataloader = EpisodicDatasetDataloader(dataset, num_episodes_between_updates=1, batch_size=1, num_epochs=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:01:00.467129Z",
+     "start_time": "2021-02-25T00:00:49.173362Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160049.195 lightning.py:1381] \n",
+      "  | Name   | Type              | Params\n",
+      "---------------------------------------------\n",
+      "0 | scorer | FullyConnectedDQN | 58    \n",
+      "---------------------------------------------\n",
+      "58        Trainable params\n",
+      "0         Non-trainable params\n",
+      "58        Total params\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 150/150 [00:11<00:00, 13.52it/s, loss=-0.047, v_num=50]  \n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {
+      "bento_obj_id": "139979157612736"
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pl_trainer.fit(ppo_trainer, dataloader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the rewards over training episodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:01:01.214706Z",
+     "start_time": "2021-02-25T00:01:00.469074Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<Figure size 864x720 with 1 Axes>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x7f4df4e8dad0>)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {
+      "bento_obj_id": "139972921706768"
+     },
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAt0AAAJlCAYAAAAGrk7qAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nOzdeXxU9bk/8M+ZmSRkAUIglIBUrwiIomwBwV3UAm5o1SsqqKhVqVqvVq2tCBZwAbG4FMW64nUrVpEiQnD9aRdFENyutlJb2TWEQEgmycyZ8/39MXNOJrOemTkzZ/u87+sWyEzOOuN5znOe7/OVhBACRERERESUNx6zN4CIiIiIyOkYdBMRERER5RmDbiIiIiKiPGPQTURERESUZwy6iYiIiIjyjEE3EREREVGeMegmIiLbue2227Bo0SKzN4OISDef2RtARORk48ePx+7du+H1elFaWooTTjgBM2fORHl5OaZNm4ZNmzbB5/OhuLgYo0ePxqxZs9C7d28AwCeffIIHHngAn3/+OTweD0aPHo2bb74ZhxxySEG2/bPPPsPDDz+MjRs3wuPx4Mc//jEuvPBCnHvuuVktb9q0aTjrrLNw/vnnaz8bPHgwSktLIUkSKioqcNppp+HWW2+F1+s1cE+IiMzHTDcRUZ4tWbIEGzduxPLly/H555/j0Ucf1V6bNWsWNm7ciLq6OjQ1NeGee+4BAGzcuBFXXHEFTj75ZHzwwQd4++23MXjwYFx44YXYunVr3rd548aNuPTSSzF69GisXbsWH330Ee688068//77GS9LCAFFUZK+vmLFCmzcuBHPPPMMXn/9dSxbtizHrScish4G3UREBfKjH/0Ixx13HL755pu41yorKzFhwgTttfvuuw+TJ0/GpZdeioqKClRWVuLGG2/EsGHD8PDDDydcvqIoeOSRR3DSSSdh3LhxuPXWW7F//34AwLZt2zB48GAsX74cJ554Io466qhOwX+sBQsW4Oyzz8ZVV12FqqoqSJKEoUOH4sEHHwQA7Nu3D1dffTXGjh2L0aNH4+qrr8auXbu03582bRoWLVqEKVOmYNiwYbjllluwfv16zJkzByNGjMCcOXPi1jlgwACMGjVKOwb/+te/MG3aNNTW1uL000/H22+/nXR73333XUyePBm1tbWYMmUKvv766xRngoio8Bh0ExEVyM6dO/H+++9jyJAhca/t2bMHdXV1GDJkCFpbW7Fx40ZMnDgx7n2TJk3C3/72t4TLf/XVV7F8+XI8++yzeOutt+D3++OC2w0bNmDNmjVYunQpFi9ejH/9619xy2ltbcWmTZswYcKEpPuiKAp++tOf4t1338W7776LkpKSuHWtWLECc+fOxSeffIJ7770XtbW1WmZ/1qxZccvcvHkzNmzYgCFDhiAYDOKaa67BMcccg7/97W+YOXMmbr75Znz77bdxv/fll1/iN7/5DebMmYOPPvoIF1xwAX7+858jEAgk3X4iokJj0E1ElGfXXnstamtrcdFFF2H06NG45pprtNfmzZuH2tpaTJ48GdXV1fj1r3+Nffv2QVEUVFdXxy2ruroajY2NCdezcuVKXHbZZejfvz/Ky8tx00034Y033oAsy9p7rrvuOnTp0gWHHnooDj300IQZ4aampqTrV/Xo0QMTJkxAaWkpKioqMGPGDHz88ced3nPOOedg4MCB8Pl8KCoqSrqsc845Rzsu5513Hs4991x8+umn8Pv9uOqqq1BcXIxx48bhpJNOwqpVq+J+f9myZbjgggswbNgweL1enHPOOSgqKsKmTZuSrpOIqNA4kJKIKM8WL16Mo48+OuFrM2fO7DSwEAD8fj88Hg/q6+sxYMCATq/V19ejR48eCZf1ww8/oF+/ftq/+/XrB1mW0dDQoP2sV69e2t9LS0vh9/vjltOtW7ek61e1trbinnvuwQcffIB9+/YBAFpaWhAKhbRBkDU1NQl/N9by5ctx4IEHxu1Lnz594PF05Ib69u2L77//Pu73d+zYgddeew3PPfec9rNgMIgffvhB1/qJiAqBQTcRkcWUlZVh+PDhWLNmDcaOHdvptdWrV8f9TNW7d29s375d+/eOHTvg8/nQs2fPTvXW6ZSWlmL48OFYu3Zt0nU99dRT+Pe//41ly5ahuroaX331Fc4++2wIIbT3SJKke52J9mXXrl1QFEULvHfu3ImDDjoo7r01NTW45pprMGPGjKzXR0SUbywvISKyoF/+8pd47bXX8Oyzz6K5uRn79u3DokWLsGnTJlx33XUJf+eMM87A0qVLsXXrVrS0tGDRokWYNGkSfL7M8yu33HILli9fjieeeEIrZ/n6669x4403ApGsdklJCbp164a9e/fi97//fdpl9urVS3fnlSOPPBKlpaV44oknEAwG8dFHH+Gdd97BaaedFvfe888/Hy+99BI+/fRTCCHg9/vx3nvvobm5OeP9JiLKFwbdREQWVFtbiyeeeAJvvvkmjjvuOJx00kn46quv8MILLyTM9gLAueeei7POOgtTp07FySefjOLiYtxxxx1ZrX/kyJFYunQpPvzwQ5xyyikYM2YM7rjjDpxwwgkAgEsvvRTt7e0YO3YsLrjgAhx33HFpl3nJJZegrq4Oo0ePxrx581K+t7i4GI8++ijef/99jB07Fr/97W+xYMGChOUuRxxxBObOnYs5c+Zg9OjR+MlPfoJXX301q/0mIsoXSUQ/CyQiIiIiIsMx001ERERElGcMuomIiIiI8oxBNxERERFRnjHoJiIiIiLKMwbdRERERER5xqCbiIiIiCjPXDMjZWNjCxSl8N0Re/asQEMDJ2jIFY+jMXgcjcHjaBweS2PwOBqDx9EYbj6OHo+EHj3KE77mmqBbUYQpQbe6bsodj6MxeByNweNoHB5LY/A4GoPH0Rg8jvFYXkJERERElGcMuomIiIiI8oxBNxERERFRnrmmpjuRUEhGY2M9ZDmQt3X88IMHiqLkbfluweNoDKOPo89XjB49quH1uvo/JURERGm5+krZ2FiPLl3KUF7eB5Ik5WUdPp8HssxgMVc8jsYw8jgKIdDS0oTGxnr06lVjyDKJiIicytXlJbIcQHl5t7wF3EROJkkSysu75fVJERERkVO4OuhGJHAgouzw+0NERKSP64NuKznvvDMxefIEhEIh7WerVv0Zxx5bi1de+WPWy/366//Db38706Ct7OyOO27DGWecClmW87L8fDvvvDNx0UXn4tJLL8TFF5+HlStfM3uTAAA7d+7A6aefbPZmEBERkUEYdFtMz569sG7d37V/r179OgYPHpLTMg899DDMnj3PgK3rrKlpH9avX4d+/Q7AX//6vqHLLmQQP2/efCxd+iLmzr0X999/L3bvri/YulHgfSUiIiJzuHogpRVNmnQm3njjdYwbdyx27NiO9vY2HHzwAO11v9+PBx64D1999SUAYMKE0zB16mX49NONeOCB+/D00y9o77388qm4/vobIYTA4sUP4skn/xc7d+7AlVdOw1ln/RQffvhXtLW14bbbZmHYsOEAgFde+SNefvklVFR0xbhxx+DVV5dh1aq3E25rXd1qHH30MRgzZhxWrfozTjhhPADgnnvmYMCAgfjv/74QAPDtt5vxq1/9EsuWvQa/vwUPP7wI//rXNwgEAhgxohbXX38jvF4vrrvuKgwcOBhffvk5unXrhnvv/R1uvfV/sG/fPgQC7Rgy5HDccstvUFRUhGAwiN/9bgE2btyAHj16YODAQdizpwHz5i0AADz//FK8997bCIVC6NWrN371q9vRs2evlMf+4IMPQdeu3VBf/wN69apOuZyzz56Ep59+Hj16VOHmm38BSZJw330PorFxD6ZPvxivvbYa69evw+OPP4pAoB2hUAiXXHI5TjllAgDE7evChQ/hlVeWYdmyF1BeXo5x447N6XNERERE1sKgO+Kvn+/EXz7bafhyJQk45ogaHHOEvu4OI0fWYvnyl9HU1ITVq1/HxImn4+uvv9Jef+aZJ6AoCp599o/w+1tw9dWXY8CAgRg37hi0trZi8+ZvcMghA/Htt5vR3Lwfw4ePxMaNGzqtY9++fRg69EhcffW1WLt2NZYseQiPPvoUNm/+Bv/7v8/g6adfQI8ePfDgg/en3NY33vgzrrvuRgwdegQefPB+7N5dj169qnHaaWfiwQcXakH3qlUrcdppZ0CSJDz88CIMHz4St912BxRFwW9/OxOrVv0ZZ511DgBgx45teOSRJ+Dz+SCEwOzZ89C9eyW8Xgl33nkHVq1agbPPPg8rVryC77/fheeeW4ZQKITrr78avXv3BgDU1b2Bbdu24bHHnoHH48Hy5X/C73//QNps/2efbUL37pU45JBBaZczcmQtNmz4GCeeeDJ27doJIQRkWcb69eswalQtAGDQoEPxyCNPwOv1Ys+eBlxxxTSMGTMO3bp1i9vXzZu/wbPPPoWnn34eVVU9sXDhvbo+L0RERGQPDLotRpKA8eNPxdtvr8Xbb6/Fo48+2SnoXr9+HW644eZI54gKnHLKT7B+/TqMG3cMJk48HatXr8T1198UCXTPTDjQrbS0DMcccxwA4PDDj8Dvf/8AAGDjxg0YN+4Y9OjRAwBw2mlnYu3aNxJu5z//+TX279+PkSNrIUkSTjjhJKxevQrTpl2GYcNGwO/3Y/Pmb3DQQf+Ft96qw2OPPQ0A+Mtf3sdXX32Jl156HgDQ1taG3r1/pC331FMnwucLfywVRcGLLz6HDz/8G4RQ0NTUhC5dugAAPvlkAyZOPA0+nw8+nw+nnDIBn322UVvH119/hcsvnwpE+rFXVFQkPeYzZ/4KQghs374Nc+fei6KiorTLGTmyFuvXr0N1dW8cdthQCCHw5ZdfRILuMQCAvXsbcc89c7Bt2xZ4vT40Ne3Dli3fYejQI+L2dePGDTj66GNRVdUTADB58jl49903035eiIiIyB4YdEdkko3ORDZ9kSdNOgNXX30Zhg8fie7dK2NeFYiNo9XAeuLEM3D11Zfiqquu7RToxiouLtL+7vF4EAqFa4qFEAD0daN4/fUVaG7ej/PPPwsAEAwGUFZWjmnTLotsy+lYvfp1jBgxCgcd9F/o00c9tgJ3370Q/fodkHC5paVl2t/ffHMNPvtsEx555HF069YVTz31BLZu3ZJ2W4UQuPTSy3HGGZN17cu8efNx8MGH4J133sLdd/8WRxwxDFVVPVMup7Z2DJYufRLV1b0xatRoCCGwYcM6bNjwMaZPvwoAcP/99+KYY47H3XffB0mSMGXKTxEItCfc1/D+EBERkVNxIKUF9et3AH72s5/j0kuvjHuttvYovP76Cggh4Pe34O2316K2NpxZ7dOnDw466GA88MBCHHTQwVGBrj4jRozChx/+FXv37gUArFnzesL3BQIBvPXWWjz++LP4059W4k9/WokVK+ogSRI+/XQTELkBeOutOrz++ms47bQztd895pjj8dxzS7UOLXv37sWOHdsTrqe5eT+6d69EWVk5mpv3480312ivjRxZi7Vr34Asy2hvb8c773RkhY899ngsX/4nNDU1adv7zTf/TLv/48efgtGjx+K5555Ju5w+fWrg8XiwZs0qjBo1BrW1R2H16tfh8/nQp08fAMD+/ftRU1MDSZLw8ccfYvv2rUnXPXJkLf7+97+isXEPELmpISIiIudgptuiJk/+acKfX3bZlVi0aAEuueQCIDKQcuzYo7XXTzvtTMydOwt33DEn43UOHDgIF110Ca65ZjrKyspRWzsa5eXxZRkffPAe+vU7AP37/7jTz089dSJWrVqBYcOGazcAGzduwJ133q2954YbfolHHnkIl112ISRJQlFRMX7xi1+ib99+ceuZOPEMfPDB+7joonNRVVWFYcNGoL09nCk+++xzsXnzPzF16n+jsrISBx54UNTvnY59+/bi+uvDGWdFUXDOOedj4MBBaY/BNddchyuumIqLL7407XJGjRqNzz77FL16hQdolpSU4Mgjh2vLmjHjOtx//3w8+eQfMGTIYRgwYGDS9R5yyEBMmzYdM2ZcgbKycowbd0zabSUiIiL7kIRLnms3NDRDUTrv6q5d36FPnwPzul67TV/u97egrKwcAPDkk49h+/ZtmDVrrtmblfA4qtsaCARw22034aSTTsGZZ55t2jbaQT4+j4X4HllNdXVX1NfvN3szHIHH0hg8jsbgcTSGm4+jxyOhZ8/E48iY6aZOHn309/j8808hy0H07dsPt956u9mblNQNN/wcwWAQgUA7amvHYNKkM8zeJCIiIqKEGHRTJ7/85a/M3gTdHn98qdmbQERERKRLQQZSNjY24mc/+xkmTJiAM888E9dddx327AkPGNu0aRPOOussTJgwAZdffjkaGhq030v1GhERERGRXRQk6JYkCVdeeSXq6uqwcuVK9O/fHwsXLoQQArfccgtmzZqFuro61NbWYuHChUCkhVqy14iIiIiI7KQgQXdlZSWOOuoo7d/Dhw/Hjh078Pnnn6OkpAS1teEZ/KZMmYI1a8Jt4VK9RkRERERkJwXv0x2eZfBFjB8/Hjt37kTfvn2116qqqqAoCvbu3ZvyNSIiIicICYEf2oMIuaORGFFBBBQFP7QHLTfxXMEHUs6dOxdlZWWYOnUq3nyzcNNcJ2rf8sMPHvh8+b/vKMQ63IDH0RhGH0ePx4Pq6q6GLtMO3LjP+eLmY9kckLGnqRVdu5eivCi3S7Kbj6OReByNYeZx3L6/Fb5ACNVV5dqs3VZQ0KB7/vz5+O6777BkyRJ4PB7U1NRgx44d2ut79uyBJEmorKxM+Vo2EvXpVhQl7z20M+mLfN55Z2LBgkU4+OBDslrXk08+hksuuRxFRUU63p3csmUv4NRTJ6JHj6qclmOkTI9jcXExiotLtJ/dc89C1NT0Tfl7l112ER577CmUlHTJeXvfeGMl/va3DzBv3oKMfk/d9qKiYshyEFOmTDW093i2fbp37tyBK6+chlWr3o57TVEU1/VjdXMPWqO5/Vj6Qwr87UE0yAr83uxviN1+HI3C42gMM4+jIgR2tQVR7vVg9+7mgq/fEn26Fy1ahC+++AJ/+MMfUFxcDAAYOnQo2trasH79etTW1uKll17CpEmT0r5GiT399OO48MJpBgTdL6K2doylgu5MzZs3P+Obl2eeeSFv25MJddu//XYzLr98KsaNOwa9elUXbP2yLMPnYzdRokJQH39b6yE4kX21hhQIIVCew01svhTkyvrNN99gyZIlOOiggzBlyhQAwAEHHIDFixdjwYIFmD17Ntrb29GvXz/cd999QOSRdbLX3OC6667CkCGH44svPsPu3bsxfvwpmDHjegDAU0/9AW+9VYfi4hJIEvDQQ4/hD394BAAwY8blkCQPHn74Mfz973/Fyy+/CFkOAgCuvfZ/UFs7BohkVCdOPB0ff/wRGhp248ILp+Lccy/A0qVPYvfuesyc+SsUF5dg9ux5aGjYjccffxSBQDtCoRAuueRynHLKhLTbuXv3bjzwwAJ8//0utLe345RTJuCSSy4HAHz11Zd44IGFaGtrRZcupfif/7kZQ4Ycjk8+WY/Fix/Ek0/+LwBo/1669Hls2fIf3HXXb9HW1gZFCWHSpDNx0UXTMjquxx5bi+nTf4YPPvh/aG9vw9VXX4sTTzxZe23t2vfRpUsX/O53C/DJJx+jqKgYZWWlePTRpwAAq1e/jhdf/F9IkoS+fQ/Arbf+Bj16VCEYDGLRogX45JP16N69EgMHDu603uefX4r33nsboVAIvXr1xq9+dTt69uyVclsPPvgQdO3aDfX1P2hBd7LlnH32JDz99PPo0aMKN9/8C0iShPvuexCNjXswffrFeO211Vi/fh2eeOJRtLcnPo8DBw7Gl19+jm7dumHhwofwyivLsGzZCygvL8e4ccdmdJyJSB812LZa7SmRXbWEFPg8Eko81ikrURUk6B44cCD+8Y9/JHxt5MiRWLlyZcavGa1ZDqElZHypiScooVSSUOHzZvy733+/C4sXPw6/348LLpiMM86YjO7dK7Fs2QtYsWINSkq6wO9vQXFxCX75y19h+fKX8eijT6GsrAwAcNRRY3HqqRMgSRK2bPkPbrjh51i+/A1t+W1tbXjssaexc+cOXHLJBZg06UxceukVWLnytU6Z4p49e+GRR56A1+vFnj0NuOKKaRgzZhy6deuWdDv79/8x5s2bhcsuuxLDh49EMBjEDTfMwJAhh2H48FG4/fZb8etfz8Lo0Udh/fp1uP32W/HHP76W8ni8+uqfcOyxx2PatOkAgKampqTvVW8aAMDr9WpBPCI3dM888wK2bPkPrrnmCgwbNqJTVn/z5n9i48b1eO65l+HxeLT1fPvtZixZ8ns8+eRz6NWrFx5//FEsWnQf5sy5BytWvIKdO3fguedehizLuPban6GmpgYAUFf3BrZt24bHHnsGHo8Hy5f/Cb///QOYPXteyv397LNN6N69EoccMijtckaOrMWGDR/jxBNPxq5dOyGEgCzLWL9+HUaNCncAGjToUDz22FMQQkp4Hnfs2IZHHnkCPp8Pmzd/g2effQpPP/08qqp6YuHCe1NuKxFlR8T8SUTZCwmBVkWgm89jqVpuFZ8hW9hJJ50Mj8eDiooKHHjgf2H79m3o27cf+vXrj7lzZ2PMmLE4+ujjUFZWnvD3t2/fhjvvvB319fXw+XzYs6cBDQ27tQzrKaf8BABQU9NXy6geeOBBccvZu7cR99wzB9u2bYHX60NT0z5s2fIdhg49Iul29upVjY0bN3TqNuP3t+A///kPqqp6oaioCKNHh9tI1taOQVFREbZs+S7l8Rg+fAQeeeQhtLW1YeTIWowcWZv0vanKS844YzIA4Mc/PgiDBoWzu8cee4L2et++B0CWZdx771yMHFmLo48+Dohk3cOlHuHjN3nyT3HZZRdFXtuASZPOgM/ng8/nw4QJk/DZZ5sAAH/5y/v4+uuvcPnlUwEAoZCMiorE9V6I3DAIIbB9+zbMnXuvVi6UajkjR9Zi/fp1qK7ujcMOGwohBL788otI0D1GO4/z58/Fli3fJTyPp546USsr2bhxA44++lhUVfWM7Os5ePfdwg18JnILBt1ExvGHFMCipSVg0N2hwufNKhudTrYD1wB0Ggjo8XgQCoXg9Xrx2GNP4/PPP8Unn6zHFVdMxf33P4xDDhkY9/t33nk7rrvuRhx//IlQFAWnnHIsAoFA1PKLY5YvJ9yO+++/F8ccczzuvvs+SJKEKVN+ikCgPeV2CqFAkiQ88cSzcfXBmzd/k/AOVJIAr9cHITqOV/T2nnjiyRg69EisW/chnnvuGaxa9WfMmjU37XFMJfxEt/O2VFRU4Nln/4iNGzdgw4aP8eijD+Opp56DEIjbbvWfqR4NCyFw6aWXa8F+OuoNwzvvvIW77/4tjjhiGKqqeqZcTm3tGCxd+iSqq3tj1KjREEJgw4Z12LDhY0yffhUQOY/HH38C5s1bkPA8lpaWddpmIso/9avGbxxR7lpkBUUeD4o91gy6rblVlJTf34K9e/dixIhRuOKKq3HwwQPw7bf/AgCUlZWjpaVjpG5zc7PWseP111d0CmBTKS8vR3Nzx3L279+PmpoaSJKEjz/+ENu3b027jLKycgwbNgLPPfeM9rPvv9+FhobdOPDAgxAIBPDJJ+uBSAZZlmX0738g+vbtix07tqOpqQlCCLz1Vp32+9u2bUVVVU+cdtqZmD79Z/i///tS1/7EWrXqzwCArVu3YPPmf+Dww4d2er2xsRHt7e0YO/ZoXHPNdaioqMCOHdsxatRo/P3vf0VDw24AwMqVr2k18rW1o7FmzRuQZRnt7W14882OiZyOPfZ4LF/+J61MJRAI4Jtv/pl2O8ePPwWjR4/VjmGq5fTpUwOPx4M1a1Zh1KgxqK09CqtXvw6fz4c+ffoA2nnsq+s8jhxZi7///a9obNwDRD4/RGQ8EfcXIspGUBFoVxTLZrnBTLf9NDc34/bbb0Ug0A5FUTBo0KE44YSTAABTplyMX/ziGpSUdMHDDz+GX/ziJvzmNzeja9euOOqoo9G9e3dd6zjvvCm4++456NKlC2bPnocZM67D/ffPx5NP/gFDhhyGAQPis+qJzJo1Fw899DtccskFQCQQ//WvZ6Fnz164664FnQZSzps3H0VFRaiu7o0pU6biiiumoaqqCsOHj8S///0tAOCdd97E2rVrUFTkgyRJuOGGXyZdd3RNNwDcdttMHHroYQCAUCiE6dMvQltbG2655TdxXVp++OF7zJ8/D6FQCKFQCGPHHo3DDz8CHo8HV199LW688drIQMp+uOWW3wAAzjrrp9i8eTOmTj0f3btX4tBDD0djYwMAYOLE07Fv315cf30446woCs4553wMHDgo7TG85prrcMUVU3HxxZemXc6oUaPx2WefauUvJSUlOPLI4dqy1PP4hz8sSXseDzlkIKZNm44ZM65AWVk5xo07Ju22ElHmBNi9hMgI6rg8KwfdknDJc+REfbp37foOffocmNf15lJeQh2MOo5qhxJ1sKnb5OPzWIjvkdWwl69x3H4sGwMymuQQuhd5UZnD5DhuP45G4XE0RqGPoxACO9uD8EgS+pTk1jY5V6n6dFv3doCIiMjhOJCSKHcBIRBUrDuAUsXyEnKVv/xlvdmbQESk6ejTbfKGENmYXw43byizeNBt7a0jIiJyMGa6iXIjhEBLSEEXjwSvBXtzR3N90O2SknaivOD3hyg3nAaeKDdtikDIwr25o1l/C/PI5ytGS0sTAweiLAgh0NLSBJ+vWMe7iSgRZrqJcuMPKfBIEkptEHS7uqa7R49qNDbWo7l5r453Z8fj8UBR2L0kVzyOxjD6OPp8xejRo9qw5RG5TUdNN8NuokwJIeAPKSj1euCxeGkJ3B50e70+9OpVk9d1sP2QMXgcjcHjSGQtDLWJsudXBBSblJbA7eUlREREZuI08ETZa5FD8EoSunisn+UGg24iIiLzsKabKDshIdCmCJR5PZBsUFoCBt1ERERminQvYdSdVlDhQaIO/pACIQTKffYJZe2zpURERA7DTLc+AUXBjrYA2jmgniL8IQU+j4Rim2S5waCbiIjIPB013Qy7U675e6cAACAASURBVAmJzn+Su8mKQFtIQbnXa5vSEjDoJiIiMg+ngdeHh4eitYTCTzzs0rVEZa+tJSIichAGk/oo6sydvDuhSGlJsceDIpt0LVEx6CYiIjKBEII13TrxOJFKVgQCioIym2W5waCbiIjIRGoG1+ztsDj2MyeVPzKYlkE3ERER6aIGkJIkhbPeLJ1ISmG4TRGtIQVFNiwtAYNuIiIic6hhJC/E6XHAKaHThDj2C7jB7zoREZE5tKBb6vxvisfyEkIkyw0hbFlaAgbdRERE5lADSU+kzzADyuTUKXF4jNxNnRCnyEa9uaMx6CYiIjKB2rtEvRCzdCI5oQ045UFyK0UrLfHYakKcaAy6iYiITBA9kBLM4qbEY0OtIQVCCJR67Bu62nfLiYiIbEwrL1H/zdAyKa28hIfItfyKgFeSUGLDriUqBt1EREQm4kDK9DiQ0t0UIdAaUlBq49ISMOgmIiIyR0fLwEh5CSPKpPgUwN3alHAfe7t2LVHZe+uJiIhsKrZlICWnMNPtav6QAo8koYvNvywMuomIiEygduRQwwgGlMl1TI7Do+Q2wiGlJWDQTUREZI6OTDe7l6QjYv4k92hTBBQHlJaAQTcREZE5YqeBZxY3MSEEj42LtYYUSA4oLQGDbiIiInNwGnh9RJK/k/MJIeAPKSj1SNoTITtj0E1ERGQCNXkrgeUlqShRf+cxcpeAIhBySGkJGHQTERGZQ5sGnpnulKIrS1hl4i5+JVxaUsqgm4iIiLIlIlPAa91LGFAmpPXoliTemLiIWlrSxSGlJWDQTUREZBIRbhfIloGpqT26wwGLvY/S9+1B7A3KZm+GLQSFgKwIx2S5waCbiIjIHGr4KElSJItr74AyX6IHnNr9CAUVAdnuO1Eg/pACSJJj6rnBoJuIiMgcIirL7YyH5/mhDqT0QrJ9CY5ga0jd/CGBEo8Er0NKS8Cgm4iIyBzhmu7w3yXWdCelBqlOyHTD9gUyhRFUBIKK4qgsNxh0ExERmUMIobULlBiMJRU7c6edCZ5nXfyh8PONMo+zwlRn7Q0REZFNdCovcUgWNx+iB1La/Rgx6NanVVFQ7PHA54BZKKMx6CYiIjJBXHmJ2RtkUdH9zO1cEy2EAIRgGZEOISFQ7LCAGwy6iYiIzNF5IKVk22Ay3zr6mUuOKHy3/x7knyKcGaA6cZ+IiIgsTwh2L9EjNgCza9AqEvyN4gkhoAgRbqXpMAy6iYiITBCd6QZrupNSy3DUGMyux0nE/EmJqS0iHVhdwqCbiIjIDAId2bx8tgz0hxQ02ngWRLXLi91jMC3oZtSdUucZSJ3FiftERERkK/kcSNkSUtAsKzreaU0iEqyoQbdtg1bR6Q9KQtEGztr9Niseg24iIiITxNZ052sa+JBi7wnmFbW8JPJvu+4Ly0v0YaabiIiIDNW5T7eUt2BMtm1qOCz65gR5vDnJN3W77bn1hcOabiIiIjJUIaaBV4RASAiIyP/bkRKpfXdMNwsbn4tCUI+Nx/ZV/PEYdBMRERWYGgR3Li8xXsgBsZ0QMTXdJm9PtkSSv1NnWnmJ82JuBt1ERERmUXty5Cvoji4tsWugp5bh2H0gZfR223QXCkKBACT7d6tJxFeoFc2fPx91dXXYvn07Vq5ciUGDBmHbtm249tprtffs378fzc3NWLduHQBg/PjxKC4uRklJCQDg5ptvxnHHHVeoTSYiIsoLNejKd59uuwfdQghtIKX2MzM3KAfMdOujTobkmHKiKAULuk8++WRccskluPjii7WfHXDAAVixYoX277vuuguhUKjT7z300EMYNGhQoTaTiMgVdrQF0M3nRYXPa/amuJIWdGs13ZJW62tksGH3oBsIp4g9kGw/OU4ngtOQJqM4tLQEhQy6a2trU74eCASwcuVKPPnkk4XaJCIiVxJCIKgIBO36nN4B1EMfOw280bFYKDa9arNgRu1kEd0y0K6Y6dZHidxkOVHBgu503nnnHfzoRz/C4Ycf3unnN998M4QQGDVqFG666SZ069bNtG0kInISxtzmiS0vyVcW1+6ZbnXzPVH173bt/CE6nQsb3gEVCDPdBfDKK6/g3HPP7fSz559/HjU1NQgEArjrrrswZ84cLFy4MKvl9+xZYdCWZq66uqtp63YSHkdj8Dgaw87HMaQI7N7TjG5dilBd0cXszbH1scxWmxzC3r0Sqrp2QbeSIvjaAmhvbkevqnL4PNn1OEh0HPfuaUaRCGcPqyrL0MVm5UTtcgiNkeNU6vNib2MLKiu6oLJLUd7Wma/PY3FbEP7mNgBAVfcylBbZ61xkKtvj2NTYghKvB9XdSg3fJrNZIuj+/vvv8fHHH2PBggWdfl5TUwMAKC4uxkUXXYQZM2ZkvY6GhmYoSuHvjquru6K+fn/B1+s0PI7G4HE0ht2PY0gI+FsDkNpl+FqDpm6L3Y9lttoVBf62IBplBe1eD5rlEPwBGfUhAV8Wab5Ex1EIgX1tQRRLEgKKgoaQguIsA3qzqMdpr6zA75Hgbw1gTzCEYJ5uHvL5eVTPMQDslhV08drrXGQil+PY1BpAqdeD+nbZ8O0qBI9HSprotcQZX758OU444QT06NFD+5nf78f+/eETJoTAG2+8gSFDhpi4lUREzsDpqM2XqqbbKLIIr0gN4u1YldG5vMTeWNOtj2KV4DQPCpbpnjdvHtauXYvdu3dj+vTpqKysxKpVq4BI0H377bd3en9DQwOuv/56hEIhKIqCAQMGYPbs2YXaXCIi54pc8e1aG+sE8TXdkcDYwFrfUOT8Ftm460d0lxfb9+lO8nfqIPLQwcdKChZ0z5w5EzNnzkz4Wl1dXdzP+vfvj9dee60AW0ZE5C684JsvtmVg7M+NoA6i9GkBvf0okX2QHDAjpX03vHDUbjVOHUjp1Aw+ERElISJXf8YA5onLdKs/N/CkyCI8s5+dg251m6NbyNlxPxCb6bZruj7PlKhyIidy6n4REVESrOm2AC2D2zENPPJQ0+21edawU3lJ+H9s+8kVUdttzz3IPyVyZDwOLS9h0E1E5DZaTbfZG+JehejTHYoMorRzf2s18xn9RMB+exHGmu70mOkmIiJHYabbfPHTwHf+uRFkIbTSEqOXXSgC4RKZTkG3HXckhgN2IS9Y001ERI7SEXTz0m+W+JaBUucXcl6+gCwAn5S/2S4LQYjIIEqpowzHjvsBdV/U+nq77kSeqU9jnDoNPINuIiKX4fXefEkHUhq0/FCkR7c3KktsR7E9m+1e6mv7Dix5ppWX2Pw8J8Ogm4jIpZhtM0/sUwajs9HR7QLt3N9a5LmtYiFpHdgliU+ZklBiyomchkE3EZHLqI9wedk3j4iUTESXTcDAwDi2Rzdser4VIRAdgkk2HRCKqBsIpwaURlBEZPZRuz/SSKJgk+MQEZE1cCCl+dRaZZXRZQdyZEG+qJXY8XyL2PISSLbcD0Rlup0yGDQfFAeXloBBNxGR+zDoNl+yyd6NKjsIqfXcWnsUew5BTFReYltCaLcN9jsThaEI4dhBlGB5CRGRiwlh20f1dhcbTKqlJkbWdEeXltgz5A6XG3R6IiDZcz8Qnem28T7km9Mz3Qy6iYhcJjrO5sXfOiQYd0JkIeD1xNZCG7PsQhIQnWYntOvNA2Jquu26D/mm1nQ7lZP3jYiIEuDMeOYTMQMEtZ8btOyQ6FzPbddAL1Htux1vHlTqsFk+YUpMEcKxU8CDQTcRkfuwotR8iWq6jQqMQ5HA2+eA4CXRcbLrpze2NzvFY3kJERE5SqdMt10jGJtLNEDQqFrfkBLfLtCOdcRCiLggTLLpgFB0ml3TrnuQXyIyxoQDKYmIyJF48TdH0ky3AXdBao9ur81roQXCkWpcn24zNyoHnVoGmr0xFqRE/mSmm4iIHKPzQEpe/s0QW6sMA3tQJ+rRLdmwjlgrx4itTbfXbkTpmG3RvvuQP9oU8GZvSB6xTzcRkctwIKX5Ema6DSo7kCOD0ew+IE0kCMLsnCWOPud23Yd8UiJHxamzUcLhNxRERJQAa7rNJyDiggvDBlImGERpxzpitdzAKSFYR003p8dJxA2ZbifvGxERkSUlLi8x5iYoPDFOgmXnvuiCEgkyn3a8eYjmlBuIfGBNNxEROU50ba+dAxg7Sz4NfI7LFQKyQHym24ZPNVKVl9itPh0xLQNtuPl5p55Tu5dFpcKgm4jIZVjTbQ3xNd2556OVSPDidUC6UCsviRkQateIlTNSpsbyEiIiciT1kb0dM4ZOIBAfdRsRjKntAhNmum0W6qmfzXzN3Flo0d1Y7Lj9+aZEdXdxKgbdREQuI6L+48+Lf+Gpk4Dko6Zb1ibGiVm2ZEw7wkJSt7dTeYnU+TW7EEJEeo539GPnDW9nigifa3YvISIixxBRg5V42S+8jtpe47uXhLQe3fav6U5cXmJvUuT/KJ7Tp4AHg24iIvcJd85w+NXNwhJN+gKDyg6c0qMbKQZSwoY3ENGDKNmrOzHF4VPAg0E3EZH7dMp088pvmoTlJTkuU07Qo9uoZReaiNT4RrNrwKptr2TfEpl8Y6abiIgcSNg2eHEC9UYn0TTwyLHWVxaAN0HgYsfBe6lqfG03KDTyp5TgZxSmnm8nc/r+ERFRDBHVC9duwYsTJArAEr2e8XKFSDgbZa7LNUuiXua2HWQXdaNl1xKZfFMipVFOxqCbiMhlOk9HTYWWaKZFGNCZQ4kELsnKS3LNoheaSFT3HvWanbCmOz2WlxARkeMIZttMlSzTnWswFlJ7dCeIXOw4cDbRwDq7fm6jnyh13GyZsxOtIUXr524VagtFDqQkIiJHcvblzbqSxTu5BpRy5PcS1nSry85u0aZIlOmOfs2OpKjJX8zYByEE6gMy9sshE9aenNoekpluIiJyFE5Hba58ZbqTzUYJm04qo5ZBRbPjfiBZeYkJOyELNatc+HWn4oYp4OGC/SMioihCCK28xI4dLZwgeZ/u3MJuWRGQJCnlhd1O51tJEKTYNREaHeSamelWb8ys9jlQkoxzcBoG3UREbiOENi+enQbWOYV6zPOR6fZJiQMXO9ZCC4gE+xLpumOnHYkioeNkMOjuwEw3ERE5TvTFVgK7l5gp0TTwyCEwDonEpSWwaYY4YXmJ+poJ25OL6KcbHee58Hth3aA7vEWs6SYiIseILW2w2sXXDfJZ05006LZhX/aE5SU2Dco613SbtxNyJKVstScFHQMpbXqCdWLQTUTkQpKNAxi7S1bTnUvZQUgRUISAN81JtVaolZw29sBhfbphek23eetOheUlRETkONFTkEs2q/F1iuTTwKuvZ35Sgko4V+hLEnPbraZboGPsQTS77YdGq+OXTHvKJISwbnkJBCDZsZt8Zhh0ExG5SGzrMqtdfN0geXmJ1On1TASV5BPjJFqX1anHIFmNr90+t1ZoGahE1U5b7aZFiHBAyu4lRETkGLGPue1U4+sUIpLVi5VLuBEMqZnu1EG3Xc62ku5pQKE3KEfa9krm7YOa5ZYk6w2gdsMU8GDQTUTkNh0XXitefN2go096TOlEDmUHwXQ9um02cFa9GYyfHEeKHCi77Eln0ftT6BtedRClT5Isd7OtuGAKeDDoJiJyl9jSBqs9ZnaDRK3wkOM5CYYUeJP06IYNM8Qd5SWJnwjYZT9UncZSmHTDqw6iLPJIlvveM9NNRESOk2hmPCoskeTY5xIYB5Xk7QIR3abOatFWEsnKS9Sf2WQ3NLE3uxIKf+cgR7rbeC140xLOdDufG/aRiIgiOJDSfIla4XV+PbvuJamD7o5120HStoo2/dwm2l4zarp9kQ4hVjt+inB+j24w6CYicie1NNZqF183SJrpzrLsQBECcppMt+1qutUZCh3zPCbSEi9yjswIfGUhwt1tLPi9Z3kJERE5TqJMt9Vmp3O68PFOXnud6ekIRd6frEc37JzpTvCaHW8WY894ofch3KM7/BmRIAFCWOZ7LyLb4pwbrOQYdBMRuUjHhVbSLr5UeMnCi2wyoGoruFSzUWqv2OR0q9OCJy0vsdnnNnbwbKH3QQ7fXWvlJbDQR6FjCniTN6QAGHQTEblIogyiVS6+bpGqpjubDKgadCebGAd2zHSnmBZcgv1bXRZ6H7TPiGTejJjJuGUKeLhkH4mIKIaUY19oyl7y4pLsyEJAAuDVtW57nG0lpgba7uLKSwr8vYu+MbPaDZgSNXeA0zHoJiJykeiuEFa7+LpFsj7dUDOgGZYdhARQ5PWkDFrsNhmSOi14Irat6Y46PYWOL2URnjzJa8Ee/cx0ExGRI8UOpISFLr5uISAMr+ku0lsQa5NzneppgBVb3qWTsGVgAXci3N0mcvOlbZM1jqKidqpxfqKbQTcRkZtwchzziRSP0rPJ4oaEgFdHxGKnYFVJVfduxxtFITomKDKlvARaS0n1s2eVQ9gxkNL5/0Vi0E1E5CKdMt3axdcql193SF1eknkwJHROLGKnoDtdCzm77IcqcU13IbuXdPRxt9oTLpaXEBGRQ8UPULPItdc10pZOZHhChM5H83aqhU7d4cVOtw9h8X26C1dfHxICSqKgu0DrT0cbNGv2hhQAg24iIheJvvhbLePlFkbWKwshoKTp0W1HSqqBlBYKGDMidf5rob53sS0lrda1SB00y+4lBpo/fz7Gjx+PwYMH45///Kf28/Hjx2PixImYPHkyJk+ejA8++EB7bdOmTTjrrLMwYcIEXH755WhoaCjU5hIROVJ0aYPVMl5uIZAq6pYyKjsQCJ9UPbP52WlSGaOfBpjNzJaBsqL26O5YNyz0vXfLFPAoZNB98skn4/nnn0e/fv3iXnvooYewYsUKrFixAscddxwQ+Q/DLbfcglmzZqGurg61tbVYuHBhoTaXiMixtKDbYhkvNxBCxA2qi5Zp7JFq5sb4ZduoZSBE8sGmNvzMJpyRskDrliMr6igvUb/41jiKikumgEchg+7a2lrU1NTofv/nn3+OkpIS1NbWAgCmTJmCNWvW5HELiYicL/oy647LnLUkmhE0WqZZXPW9espL7BSspiovsaO4417AL58sBLySpA22tdrNtpsy3T6zNwAAbr75ZgghMGrUKNx0003o1q0bdu7cib59+2rvqaqqgqIo2Lt3LyorK03dXiIiu4oeoKZmvOxScuAE0ZMTJZJxTTfUHse6Ut22kXogpXUCRv0EJKnjNkIt9REieUbfKNGdS2DF8hIhUOSCem5YIeh+/vnnUVNTg0AggLvuugtz5szJSxlJz54Vhi9Tr+rqrqat20l4HI3B42gMux7H9v2tKJYVVPcoRyCkYG9jCyoruqCyS5Fp22TXY5mNoKJgz54WVFWUoEeX4rjXlZZ2iLYAqnvqOyYtQRn79rXCI6U/jv59fggBVFeWZb39hSCEQH1DM3qUFaO6rCT+9ZZ2hFoD6NWzIi8Baz4+j/saW1Dq86C6aykAQPIHEPS3o1fPirz3p45dtyIE9jQ0o3t5CXqWxn8GjaL3OO7d04zyYh+qK7rkbVuswvSgWy05KS4uxkUXXYQZM2ZoP9+xY4f2vj179kCSpKyz3A0NzVCUwt/XVVd3RX39/oKv12l4HI3B42gMOx/Hfe1ByAKolxXIQsDfGsCeYAhBn9eU7bHzscxGUBHwtwWwNxiC7GuPe70pKKM5GMIPIX0ZUH9Igb89CE/3srTHsbk9iJAA6oOhnPYh35TI57IpEAJaAnGvNwVDaAnKqFeMzxLn6/O4vzUA2etBfZsMRPbBH9mHfAbdQgjsbQtC+DrWLSLHtzEQgtIc/xk0QibHsak1AOELor41mJdtKTSPR0qa6DW1ZMrv92P//vBJEULgjTfewJAhQwAAQ4cORVtbG9avXw8AeOmllzBp0iQzN5eIyBHYvcQ86Wu6MwvARIZTaNvhXKcrwYl9nx0Vqq5aFuHC/07lJZIESFK4P7bJ1BIbtwykLFime968eVi7di12796N6dOno7KyEkuWLMH111+PUCgERVEwYMAAzJ49GwDg8XiwYMECzJ49G+3t7ejXrx/uu+++Qm0uEZEjda7pjvzM/Guvi4QPdqrOHOq79IQhmUyhLUkSIJS07zOb+lA6RVdFwGZBd6KWgVC/e3mMN7Ue3TGfDwnWOIAdn1+TN6RAChZ0z5w5EzNnzoz7+WuvvZb0d0aOHImVK1fmecuIiNwj0eQ4VDhpM90ZBpTqDZOTpoEXOm9M7CR2YGihnjKlCrqt8Flw0xTwcNF+EhFRgn7BmU7GQrkR6bK46vt0Lk+B/vISu0wqI9IEYo54QhMJgvP93ZMj3VG8MZ8PywTdmXTfcQAG3URELiVJkmUuvm6RLtOtvU/nSRHqeXRQplub8CfJ63Ybi6C1Boz6WeEy3YBXin9qYJW2i8x0ExGRYwnEX/xtnTG0GT19upFBBtRpk8gg6hily97b7WMbPUhW+1ued0JWEvfAliBZoj+/IlKXEjmN076rRESUgoi5wNkl++kUHYFOknrlDIOPVJPIxC/bHudaPUbJOrl0HCM77E3ipxuFrOmOreeGhb73bhtIyaCbiMhlOl38bRKIOYWeaeCRwdMHJYN2a2qgZYUMZypaeUnapwH2oG1n9EDKAnRgCQkBJVnQbZHvPctLiIjIsSwebzme/vIS/cvTnemGZIsPQLqBlLHvs4tCZ7q1ziUJ0sjWyXQLbWyJGzDoJiJykfh+wdao7XQLo1sGZlPTbfWz7byBlOE/E3TKzut3T1bUdoHxr1llLIeIfH5Z001ERI6TqF+wBa69rmF0y0AB/VOh22VSGXWfkvbptll8ZlZNtxxZePKabvM/CYoNz2cuGHQTEblI7GXWKrWdbpM8zsgsA5pJptsusU1cL/kYtst0J/hZIW6AZCHglaSEPbAlSbLE8ctkTIITMOgmInIJIQQgRFzrMitcfN1CQACpsrja+/QuT38wbZdJZdLvU/5LM4wV3xavUDXdibLcsFB5ieKiziVg0E1E5D7s022edAFlJhlQIURWQYvVT3e6fXJEpjvViwaRhUg4iBIWutlWhHDNbJRg0E1E5B56Z0Ok/DGydEJEFqi394NdglWRZp/sFqMlquPP97kQQkAWiQdRwkJlZU6c3CkVN+0rEZGrJWpXF67ttMLl1x3SZrrV9+k4JXpnbtSWbZNJZdK1QbTHXsSL26U8fvfkcEP21OUlFijRYXkJERE5UrLH3HYLXuxMb0CpR6YTi9glWE2X/bRLbboqYfeSSG/qfO2C1qM7adBtfs92IQQEB1ISEZETJXvMbZfgxQl0DXzUmQEVCQbo6doGi59vAaErDLP4bmgSzUiJPH/30gfdMdtmArdNAQ8G3URE7hMXdJu4LW6Tvl5ZfwZUSXATlYoVAi09RJobCbvshyrZWIp8Z7olSYI3RU03zA66XTYFPFy2r0RErpYoM8qgu7D0ZLr1ZkAzzRTaZQBi2vISSYrsjE0+uZGTGXuzlc/BjLIAvFLymxcrlOgokb1n9xIiInKchNdX91zvLCNdjKE3nBRJgrlUy4UNQtV0de+w2c2iGdspKwJFFn9awEw3ERE5VvKabmF6FwO30HOY9WZAs62JtfK5Vj+L6W4k7DQWIVHXIERulvJ1LlJNjIOop11mdi5SRPyTN6dj0E1E5DKdg273XPCsQHd5iZ5lZdy9xPrnWmuDmOZ9dsp0qwpV0x0SAkq6oDvyJwdSFhaDbiIil0jYuizmNcovAaEjs6cvA6rWxDppIKUaiDkp+ZnoCRPyWNMdUjuXpIhmLVHTzfISIiJyqsST43R+jfJLb6Zb97IkSffjeTuca73Ze6vMqKhHsu3MV6Y7GFlostkoYZEbMCVyA+qg+6u0GHQTEblEsslxYKP6WLtLNw08MqnpznIKbSufar29x+1UXpKyZWAedkJWUvfohkVuwNTPL2u6iYjIeVJ0u7BLAGN3htZ0Z1iGYYcbLL29x/M5CNF4AkjyRCIfeyALAY8kpWnFFxlIaeIxVBxWRqQHg24iIpdIXdNtlwDG3nS3w9PTpzvDKbTtEN8kywrbWbIbLSlPvcbTdS6BRcpL3DYFPBh0ExG5R6LpqN30aNdsQogMMt16poHPLlNo5RssrXtJuhsTG9V0I0lJUb5KZGQhUg6ihJXKS1z2nx8G3URELpEy022bCMbm9PSglqS81HSrgy6tfKoVnRP+2LGmO1Y+arqFEJAFUKTjaUqqbSsEBcJVs1GCQTcRkYskmRwHNgpg7Exv6YTeYExf+8Hslm2WZBPJxLL6fkRLWl6Sh++dLMIHRnd5icktA90WhLptf4mIXIt9us2VqLwnEb3BmBODlkwm/LHLZzZZGVA+SmRktUe37ppucwdSsryEiIgcKeEF1gK1nW5h9CBBPfXhsaxelqFNjpPmffkahFhI+diDYCToLkpb021uqZEQggMpiYjIuRJNptLxmNneAYwdJJuZMJaeDKgQIqtModUHIKolM47q0520jl8CIsGnUWQl0i5Qx3vNLNFx4xTwYNBNROQiCRPdLrvqmSizmu7UwZiAvkGZqbbDivRMHgQH1XTD4PMRjNRz66n1N/PGxY1TwMOF+0tE5FqJLv6s6S4kvbMtpg+Y9LbWS7hsC0ererP3drtVTNynO/ynkWdDFiJtaUn0+k0LuiNrZvcSIiJypIRBN2u6C0Z3eYn6/hTv0TtzY6JlW/lch0sxdL43z9tiFIHEJ8roG15FCMiKQJHOQJaZ7sJz2/4SEblWoi4KVmgd5ha6y0t03AiJLDOF1q/p1pfpt/p+REtXXmLUjnR0LtH3fgmSaWM5tH7szHQTEZETpQ7iKN8y6UGNNDdCTs10Z1JeYuX9iJasTt3oTHdQ0de5JHb9ZuBASiIicrYEA++s0K/XLTIZSIl05SWRP7MKWix8qvUOpMxH549CU7O8Rn33gpFHWel6dHesn+Ulhea2/SUicq3ENd0SYPGpwZ2iI0BMl+pOH4wJndOlxy3avyHNMwAAIABJREFU2jG37lk27TQAON0+GbUPshDwSfpLjqSo4LfQFLU1pDmrNw2DbiIil0hZW2qH6MXm8pLpznAbrB50651l004DgNO2DDRoJ4JK+unfY5mZ6fawppuIiJws4XTUNgle7M7Imm5tuvSMJ8eRLF1KpHeWTSeEakZm64UQCAr9nUtg8mdB0fE9cCIG3URELpHs8sqguzDykel2WtySqMNOInbqupN0IKWB2fpQJPDWO4gSJn923DgFPBh0ExG5R6qLvw1iF9vLZBp46GgZqGe69LhlWzhQVWfhzCQYs+iudJK2ZaABZEVtF5hZ0G3aNPDCfZ1LwKCbiMg9Ul387RC82F2mme5U9NY+J1q2Vc+13uMDg0sz8i359y4yYNaAyDcYWUZG5SVm1nRDuG42SjDoJiJyDwGR5Nm9eZNkuIl6/PVOA5/qnOgtw4hftnUDVa1kRk95iWSnsDv/M1IGlfCTD28GnwmzWwa6MQB14z4TEblWvh9zUwo6e1DrmwY+y5pYC59sbXCojvfaJeRWS2YSHnYDa7rlyCDKTMqNpKjtKzS9kyA5DYNuIiKXYE23ufR25tATjOWU6bbopDJqJ41MAkcL7kZCiTpSG5rpFgK+DKNY7YmKAevPRDa1+07BoJuIyCVY022uTNvhpc50Z1vTbd1AJ5Op7W2T6U7xmlEdWIQQkAVQlHH7yMjv57b6jLl1Cngw6CYico+UQbfVoxcHMLIdnt6ZG5MuO+PfzD91mzKZHMfqUvVmN+pcBEX4w5LJIEoj15+pTG6unIZBNxGRm3ByHNMkre2Nkc9Mt5F1xEbLaCBl5E8r7kciicu6JMCACWrkyN1Z5uUlYYW+4Vb3l91LiIjIkVIP6LL2LIVOIXSWd+gJxnTXh8cuO+r3rUatM9dXAmNcu718Steb3YiwM6hk3i4QFsh0uzEAdeM+ExG5VqoBXZRfmQx+lJA8GhJCZN39QfsVC8aqWnmJgzLd6bbPiNKuoBDwSlLGmWOz2i5m8kTDaRh0ExG5QKqJR1jTXRiZZKdTlfwIhE9YNoMirRysZjOQ0urSTfhjRGmXnOH079HrhhnlJZEVsnsJERE5knZdZU23aZK1bEwkbdCdY/cHK5YTaS0DdbzXrM4bmUvdBtGIdp1BRWQ0/bu27sifZnUvYaabiIgcKWWmm326CyKTY5zqnOTS/SGbjieFIiLbp2cbzcrSZkpXeUkOyw8JASWLziUw8cYlk0mQnMaN+0xE5D4pAjVmugsjkzZ/qTPd2Xd/sHKwmk1HFgvuRmdpb5CknAaDaoMocykvyXrt2VEyeKLhNL5CrWj+/Pmoq6vD9u3bsXLlSgwaNAiNjY249dZbsWXLFhQXF+PAAw/EnDlzUFVVBQAYPHgwBg0aBI8n/DVcsGABBg8eXKhNJiJyjNS1pRKgdjexcCbUCfSXlyQPxnLKdEf+tGKwmvFAU4vuRzQ9Nd250NoFZnUDZk4HGCH0P9FwmoJluk8++WQ8//zz6Nevn/YzSZJw5ZVXoq6uDitXrkT//v2xcOHCTr/30ksvYcWKFVixYgUDbiKiLGk1vAkudHYJYOzOqJpuI2b0s+K5FhkMDlXbKlpzTzqkDbpzLO0KRm6UfTl0sjGjptutZRYF2+/a2lrU1NR0+lllZSWOOuoo7d/Dhw/Hjh07CrVJRESuk6ymG5YPX+wvo+4lKYKxzPpZxy8XFj3XmfYet37InXoAMwzYh/Agyuxq9c2cBt6FSW6gkOUl6SiKghdffBHjx4/v9PNp06YhFArh+OOPx/XXX4/i4mLTtpGIyK5STdLBTHdhZFI+of1Cih9nkzWzcqyTae9xO7W6TFVeouSwD3KWgyijt8mMloFubBcIKwXdc+fORVlZGaZOnar97L333kNNTQ2am5txyy23YPHixbjxxhuzWn7PnhUGbm1mqqu7mrZuJ+FxNAaPozHsdhxbgjKa9rWiZ7dSlBd3/k9/UVsQbc1t6NmjHMXewj/4tduxzIYQAvUNzehRVozqspK0729rakVQUVBdWR73mqc1gNaWdvSuqoA3KkrVcxzb5RD27fWjsmsXdC8pymJP8mf/3hYUeTyo7laq6/2Ne5rRtdiH6oouhm6HkZ/Hfe1BtOxvQ6/KcpT44r9b7U2taA8pqO4Rf57TEUJgd0MzepYWo7o8/Wcq0e83NDSje1kxeun4TGYq2XFs2eeHBKC6e5nh67Q6SwTd8+fPx3fffYclS5ZogyYBaOUoFRUVOP/88/H0009nvY6GhmYoudxOZqm6uivq6/cXfL1Ow+NoDB5HY9jxOLaGFPjbg9gjK/DHBNYtcgj+gIzdoewm2ciFHY9lNoQQ8LcGsC8QAloCad+/PyAjqCioDypxr+0NhuAPymhQOga+6j2OQUXA3xbAnmAIAZ83y73Jj6a2AIo9HtS3y7re39IagOINwtcaNGwbjP48Nke+Ww1Jvlv7AzLaFQX1cvx5TieoCLS0BdAlGEK9P/1nKpYQAv62IBoDMoSOz2QmUh3HprYgvBJQHwgZuk6r8HikpIle02vZFy1ahC+++AKLFy/uVDqyb98+tLW1AQBkWUZdXR2GDBli4pYSEdmXNqArRVG3FSdMcYp0A+pipWsZmG33B0vXdGfYMtBO/eXzUcMcjNSFZF1eIkmm1MUrEFm1u3SCgmW6582bh7Vr12L37t2YPn06Kisr8cADD2DJkiU46KCDMGXKFADAAQccgMWLF+Pbb7/FrFmzIEkSZFnGiBEjcMMNNxRqc4mIHIk13eZIedOTQKp65Wz6WUcv16qcPJAy5TTwWe6EHHl678vh6ZQZdfGZdPFxmoIF3TNnzsTMmTPjfv6Pf/wj4ftHjBiBlStXFmDLiIispS2kICQEyg18/J+q44WVJ0xxilQDWRNJNw18tolCq55rIUTGXS1S9TK3Cl1Bd5bLDopwxtibQ9bYnEx3bu0u7cz08hIiIupsvxzCXtnYesdUF1ZmuvPPyPISxYDuD5Y81w7sapHuniCXEpmgyH0MRqFLdERkEi6nnWe9GHQTEVmMyEMmMlV5g0vLKwsq43r5VH26jch0Z/freaMOI8wo022nmu4UP1cD0UzJSvbtAmPXXyjZnGcnYdBNRGQxIuriZDTWdJuj46ZH54yLkIAkwVhONd0WnclR3c2MBlJabi/ipbvZymaCI0SedoSEyGr699j1FzbTHf7TrcGnW/ebiMiyRA7Zr6TLTFlTHOleYvH6WDvLpqYbSYJKtXtJtqwYrGZafgOYMwgwU0LtEpLkfGV7w6t1LrFZeYkCdWyJOzHoJiKyGDWQMDLbnSqoYaY7/zKu6U7R2i+XTDcsGqxqwZjT6g7SHecsWzgG1c4lRpSX5LSEzGiZbqedZ50YdBMRWYz6SNrIwCjlQEoL9252mkxaBiJppju3TKElM93ZlJdIkuV7y6c7V9ne8MpCAJKEohxj10LfgKmJhHwHn59/24Df/OFDUyZFTIVBNxGRxaiXCWMz3eGLdKJMIjPd+ZdN95JOv6j+M9Jaz2kt1zLtYw6L3jzE0h10Z7gjQUXAJ+X+ZKDQx7AQAymFEHj1/W/D+2Wx7wmDbiIii1EvwEZn8VJ1UIiskPIkVZ/0RJLdCInwwrIegAeLdv1QtOOjnxXLZGKl6zSTfU139jNRdlp/gZ8WqN+DfLYM/OfWvfhu135MGN3fcmUsDLqJiCxGy3QbWV6SYhY4ZrrzL/Oa7sjg1pizov4rl0y3FTPE2n5ZLTWZZx2Zav1nRAgBWeTeLhAmlpfkMxauW7cVFaVFOHpon/ytJEsMuomILEa9MBl5LdRTB2z1+lg7y6Z8Agk+A+qNWG413dabydGx5SVCGF7THRLh5eYy/Xv0+p3UMnBnQws2bd6N8SP7objIuBl9jcKgm4jIQoQQ2pVJMTgwShbQqC3NrB7A2Fm2Nd2xHwH1xshqj81zpWQRjFmxTCaWSFNSlE1Nt9Yu0JDyksK3DEzVQjFXaz/eCp/Xg/EjD8jL8nPFoJuIyEJEkr8budxE7FAfa2eZHttkGVBDMt0WDFZlIeDNMBizQ6Y7nWwy3Ub16IZJme583S42+QP42xe7cPTQPuhWXpynteSGQTcRkYVEXwCNrelO/Zg7dt1kLDVDnWufbqfWdMtZlUskn7XTKtINpMymT7esCHgkyZAALtXMp/mQz847736yHUFZwYQx/fOzAgMw6CYispDoa5+RNdZ6H3NTfqSbmTBW8kx3Zl1Qki3banGqnMWU5nYYAKy/ZaD+vQhGjpURJRqFPoZKjp13kgkEQ3jnk20YNqAnanqWG758ozDoJiKykHxlutOxYsmBk2T6WF0LTGKCsY4uH84R7sYB+DKMxexQ1p7uvGcTgMpCGFJaAhMmxhJ5ynT/7ctd2O8PYsKYHxu/cAM56XtLRGR70dltw7uXpOkXbOXH9G6TrqY79/IS65xrWYSjUydmutPJdB8UISArxrQL7LT+Ah1ERRgfeCpCYO26rTjwR10x+MeVBi/dWAy6iYgspFOm2+Dlpsu42Tl4sbpMp25PloHU+hznsC1W61QjRyK+rINuK+1MDIE0LQMzzDR3HKvctw0m3LiISPcSI332rwbs2uPHhDH989YVxSgMuomILKRTTbeB0UT6x9z2zhhaXdoBdTFStQzMteWa1Wq6tUAyy/S9UbvSrijY0xowaGlhai1/MpneOAQV4zqXhDcg8SRM+ZKPTHfdR1tQ1a0EtYf2NnjJxmPQTURkIR2ThEiGZ7pTYk13XokMB5ClKi9x2oVbFuEbiUynMjE6S7tfVrCrpV0LbAsh030IRd6Y6VMBo9afq0yf+KTzn11N+MfWvThlVH/4vNb/Zlh/C4mIXEQNtL2S0dnI1I91JTDVnU/ZBhuJpoHPNd6y2lMNWRHwSakzwolkM4V6KgEl/O1rCRl3u6t3AK3eTHMIApCM6/9RyBIdIYThLQPr1m1Fl2Ivjh/W17iF5hGDbiIiK4lc/byQoBjeMjA5qwViRmgNKdjWGjB8Zs9sZFxekmSWUEUIeHIMuazWqSbcuSTzfTIy5FaE0DLc/lDIsNKutN+7DGeDVZ90GFW7XMhMt0D4v2+5fn5VDfva8PFXP+D4YX1R1sVnyDLzjUE3EZGFRE9+YmSsqK+m20qhWO6CikBICO2RvJmyyXQnqr02ItMNC91ghdsFZt65pPMyct+OQCTg7lrsQ1ARCBj45dO1ZzpXZ3SmuJAtA7VBwAZt/5vrtwIATq217mQ4sRh0ExFZSEd5ibE13dCRcbNKIGYU9UmBkU8MsmXU9NdG1HRLkQ2yQotIJZJlzmYQpZFZWjXo7l1WAkmS4JeN+fYJpI+6M3nKpAgBbw6fpObWIB54+VN8/PUP2rpRoHah6iqMCDz9bTLe/3QHRg/pjZ7duxiwxMKwRz6eiMgltAuTFL4QCmFMi610l1SrdbQwgjoerpCTDCWTdaY7bjkCkpRb2JKPGQGzlW27QBg8OU5ACHglCSU+D7p4JLSEFFTm+N0TQug675kF3eHxHtloC8h44OVP8e2OJmyvb8bIQb20z0JhMt2R2VQNOHHvf7oDbYGQpad8T4SZbiIiC1FLPLwGXwz1lCVYIDY1lJqrtMJ+ZdOfOFHttWGZboscF1nJvu+0sZluBcWRbHu514OQEGgz4m5NR9eaTGrsFQh4sghag7KCxa9+jn/vbMJJI/qhoakdH3/9Q0HLS4zKdMshBW+u34rB/StxUJ9uRmxawTDoJiKyELWvr/q03agsrZ6BlE6jDqC0wkDKbCSaJdSIlmuFnvo7FTmnFniRG9Mcz68iBIICKPaEQ6JSrwceSYI/xy4mercqk9lgs7npUhSBx1//P3z5n0ZMnzQEF/9kEGp6lmHNR1u0SLiQNd251qSv++p7NO5vx8SjrD3leyIMuomILESt/VWvS0ZUlgohIhfXFC0DLdbRwgjq/hhdG5+NbGq6Y2cJNbrlmhXOtxwp68gme2tUpjughL8fJZED65EklHo98IcUQ2qd0+2a3tlgszn/Qgg8W/cPrP/6B1ww/hAce2QNPJKECWN+jC3fN+MfW/ZG3qd/mdlSj2Uu5U1CCKz5aCv69irHEQN6Grh1hcGgm4jIQtTQ2GPgTHHahDsp3qNm26wwuM4otq/pjrkRUluu5VqTbaXp0+UsB1HCwKcz6iDK4qjtKPd6oAgBfw4fHj3fO2RQ060g85Z7r/y/b/H+pztw+rgDMWFMR2Z43OE/QrfyYtR9tKXTtuaTEZnuL/+zB9vqmzFhTP+sbtTMxqCbiMhC1NprLdNt4NUw1TXKSoPrjKIO3LJCK8RsWv3FBmPR7SRzYaUznUu7QKPKZNRBlN6o7ejiCf+7RQ5lvVzdQbfO3Vf/W6D3/K/+6Du88eF3OHF4X/z0+IM7vVbk8+LkUQfgi3/vQVNLsCDfEXX7c/n8rfloC7pXFGPsYX2M2qyCYtBNRGQh4enCOy6sRlwK9Wa6jVqfVVgl0611ocnw92I7yhgRtIQXYNxTlFyEe3RnN4gShpaXKJ2y3IiMqyj3etAW6fWejUx+Tc971ZtIPRne9z/dgZff/RfGDOmNqT8ZnHAQ70kj+qGkyIt/bt1bkC++yHE2ze927cf//acRp9b2R5HPnuFrypaBDz74oK6F3HDDDUZtDxGRq4lI1lm9NBkxCFDoCdYsNLjOCGr9KyxS040snyZ0znTrD7pSb0f8ss0gi/CHM5eJcZBjmYw6iLLMGx/Elfk8aJJD8IcUdPV5s16HnvISPZ9RLdOd5n0b/vEDlq75GkP/qwpXnnEYPElS4xWlRTjuyBps/X4/mg6uQo/i/HaRznU2zbp1W1BS7MWJw+0x5XsiKY/wrl27tL+3t7fj/7P35nGSVGW+9+9EbrV0VVdXdfW+QS9009A00M2ibLIL6MVdUZzR8TrjuNyrlxmdkSsOir4u8+rFGd/xXryOCu6oQIPQQgvI3oDN1mxN03vTS+1VWZWZEee8f0SczKisyMxYTkRkVj7fz6c/2VWVGXFiy3jOE7/n92zevBknnHACFi5ciAMHDuC5557DxRdfHMU4CYIgmgIpQwgj012NegnEVCH1z4io8UfNsfjSdDMIUQrHVGW660XTHcSjG4rO2fIiSjtpxpDSmO+gu/gkocb2ue0GKyfg1eQlew6N4Ae3v4BjF3Tik+84EUmHyYSdizcuxk8efh3bdvRh6Ya2mmMIQhDnnaND43jixcO4cMMitLWkFI8sOqoG3V//+teL///sZz+Lf/3Xf8Ull1xS/N3mzZtx9913hztCgiCIJkLemFRquj3JS1R40tUBvML/46C4/31oup2WM1003cWg228hJWPWTvV/kTgVUdqX35ZIYKigQ+feCz7da7qZq4lhqRDReYlCCNz8x1fQkk7iM+9ah0y69kRhdlcrFs1px/bd/bjohPloawkv282F8H3u3vvkPqDBWr474VoU8+CDD+LCCy+c9LsLLrgADzzwQBjjIgiCaEomWQYypkh3W7sT3HTLdBdlOYzVgabbGorHz03VdAe3XEMdHWvd6vjoX7jhrZujE05FlHbarUzxmB/PbpfHvfw4V6KWvOTRF97Ajn1DePd5y9HRlnY9zOOXdkPnAg88s9/1Z/wgfJ672YkCHnjmAE47vrFavjvhOuheunQpbrnllkm/+9nPfoYlSxrPnJwgCKJekZ0LGWPQosx0s3oJxdQg91uiHgoGrVdfQbfDcgKXkNWJfl/nAkkWrC2424C1Ek5FlHZSGkNG03wF3eotA4XVOGvqErMTOn71p9dw7IJOnLVuvqdx9nS2YFHvDNz75D7oARsCVcOvx/yf/rIfubyBS09r/HjT9XOEr371q/jUpz6Fm266CXPnzsWhQ4eQTCbxve99L9wREgRBNBF2dUfQLF5xmS4WMr1C7tJ2JBlDIXZNtzttbznlPt3c32KmLrc4rngxnUuCZ+39bke1Iko7bUkNA3ndCtDdT3ncjst10F2lG+VtD72OkbE8/tu713kutGUMOHF5D/782B48vv0Q3nyit6DdLVwAKY+Hu6Bz3PvkPqxdNgtL5naEMq4ocR10r169Gvfccw+eeeYZHD58GL29vVi/fj1SqcYVtBMEQdQb9s6FGlPUkdJ6dXO/i7u4ThVSipHQGHKGZdkXUzONoJluOfaipjfgeIqP+GM82KZdoEDGQxCrmmpFlHbaExoGGMOY4S/ornnaufbpFo4B9b7Do7jvqX04d/0CHDO/0/X47Ktf2NuOhb3tuPuJPXjTCfNCuVbMp3jejvdjL7yBobE8PnbF8crHEweutt4wDKxfvx5CCGzYsAGXXXYZNm7cSAE3QRCEYiZnut0VWLmlenOc0vqnAzJATVr6gzi3y7+mm00KjO3SoyDUw7HmVhAZONPN/G9HtSJKOwnG0Gq5mPi5Ht1pumt3g3WSZ8jiydZMAu88d7nnsZXGx3DpaUuw/8gYnn+939dyalEtU+/8foG7n9iDJXNm4Phls0IZU9S42v5EIoFly5ZhYGAg/BERBEE0MfbOhVFmulV196sXippua8PidDDxm+ku/7zXoKUidXCsgzqXSILIS2oVUdppT2jQuUDOQ5FFKYiuZRnobh84Hf/Htx/CK3sH8a7zlmNGq79EKLMKtk8/fi5mdWRwt9UaXjVeu7I+91ofDvZlccnpS2J7SqUa1/KSt73tbfi7v/s7fPjDH8a8eZPbb5555plhjI0gCKKpKHUulLknRYWULm7+9ZD9VIksOpPOGDxGK0TfloFlwbHXoKXicsvGFQc6lx7dwZYT5GlQrSJKO60JDcySmLTU0IBLvBRSouwplxMcAimbPGM8p+OXf9qBZfM6cM46/w1j5MQlmdBw4YZF+PWfXsPuN0awdJ46DbX8btM8XIR3P74H3Z0ZbFw9R9k44sZ10P3zn/8cAKYUTjLGcN9996kfGUEQRJNRfpPWGENBqMvRVvfpjl/nqxKZFZQaWBGoNUcwgmi6MSnTLQLbBU4aR4yHWrfWHVRe4he3RZQSjTG0JTRkDY5uj/UBtX26zddah8Moy3Tf/vDrGBrN41PvPLFi10m345OX/bknLcQdD+/Cjbc+i8VzZqC7I4NZHRnM6mjBrM5M8ecWj90rSx7j7t7/+sFhvLx3EO87f0XNBj+NhOu9tmXLlnBHQhAE0eSUNz8JaodWvlxXzXGCr64u4FYwo7LJkG98+muXNywSChrjoE6OtW5JOwK3tPep6ZZFlG4z3QDQqjGM6QIFIZB2MW63TzjKj7PjsmSm2FrY/qNjuPfJfTh73XwsXzDT9TZUWr8ca1tLEh+74nj8+ZkDGBjJYeeBYYyOF6Z8ZlHvDPzjVSe7lrR47ab6h8f3oDWTxDknNW7LdyfCaz1EEARBeKK84E65pttF1D1dgm75KFvGVI2o6Z6a6QYSChPDcZaX6sJ7h0cn/Gq6ZRFlLecSOzLgdTuB82IZWOv98vxNMPPcvmXzy8ikEnjXef6KJyetv2zicsqqXpyyqrf4c75gYHA0h4GRHPpHcjgyOI47Ht6FH27ajs+8e52rrL8819xMsg72jeGplw7jrWcsRWtmeoWprrdmdHQU3/ve97B161YMDAxM0lDdf//9YY2PIAiiaSgPzqReNajdnZubfz1kP1UinR6khlSlC4xX/Gu6J6t9/ViuVVquWTwXH6rsAv3WPXgpopR4ncB5da2pJoGyd6Pc+tJhvLRnEB+6eBU6PXSerITdPcXpeyadSmDOrDbMmdVW/F1bJomf3fsq7nliLy49vXbTGi+Z7rse3Y1UUsPFGxu75bsTrs/4L3/5y9i+fTv+/u//HoODg7j22msxf/58/PVf/3W4IyQIgmgSZDZI3vi04u8DLtfFDY+VvbfR4UJYmm75c3xjCdIG3v55Ze4lxYGpXJiH1QphNcaJZ/3wWEQpYT4ncLU13bLuoDLSd76gG/jllh1YMncGzlu/0NM4Ko/P+4G44NRFOPW4Xvzm/tewY99QzfeXS+cqcWRwHI++cAjnrl+IzvbgE4p6w/X1+/DDD+PGG2/EhRdeiEQigQsvvBDf/e53cdttt4U7QoIgiCZhaiGl+aoqYGwqTbcwH2UXNd0xbpkqeYnKUtAgVntB0c2OP0qKKKXdnRdkEaWXRjfwk+l2OS43ha3S1/yX9+3AwEgOH7r4uEDFk07r97IXGWP4yFvXoGdmBv9x+/OOum873GVdwx8e2w1Ng6vseSPi+ozjnKOjw7SPaWtrw/DwMHp7e7F79+4wx0cQBNE0lGdESwFjwOVC1NQ2MMYAHwFMvcKtG1xRShFnptvnPrUHQ0IIx+Yofok36JZ2gfFouv0UUcL+5MmDpttNMyM3Qa/OBZ5+5Si2vXIUH7hwJVYsDFY8OWn9Pus52lqS+MSVJ2B4LI+bNm0vBtZOFDPdVZbXPzyBh547iLPWLcCsjozH0TQGroPu1atXY+vWrQCADRs24F/+5V/w5S9/GcuWLQtzfARBEE1DufZ3st1dsOWySRphZ6ZH+4mp+lStDgopfXWStAVDAma0p8IyEAE7OQZFVWMc+HT4yQvvRZSYNAlWu+dqBb1cCNz+8OvYf3QMb3/zUly0Qa3WOYi0bNm8Trzv/JV49rU+3FOlqU5Rk15ll9/9xB5wDlw2TbPc8BJ0f/WrX8XChaZ+6Nprr0VLSwuGh4fxzW9+M8zxEQRBNA1TCylNgspLhHAXUKuyKIybck9gVS4wfnG7/8spBUPCtSa2EdDF5MZFUZPn3oso4eOpiZfrDhWCbiEEfnrPy3h+9wBWL+nCpRvVB6RBpWXnn7IQG1bPwa0P7MQrewcd3yOvv0r7Y2gsjwe3HcCZJ8zF7K5WnyOpf1y7lyxeXJpZdXd344YbbghrTARBEE2JKNM9aj4f+/olTsmBSuxOD+Yrq/roO2z8arGLhXs+fI5rLzs+RxedCyRZ7ScvbvAnL/FeRCnx8tS9AL9fAAAgAElEQVTE/XF3LtAUQuDn976KB7YdwDsuWonVi7tCaYfOJj1R8758xhj++tLV2PPGCH5w+wv48kc2orfsPcLqEFtp/Ju37kFB57j8zOmtnnCd6b7yyivxta99Dffeey8GB51nMgRBEIR/nCwDYStCCrJcVxm3GCUHKin3BGYs3gy+8Nm+3S478OJz7GrZiM8y0HQuiUcm47eI0r4+L09N3GymU6ZZCIFf3/8a7n1qHy7euBhnnDAPiZAec6goopb67pFsHv9n03bwssdz1Zx3RscL2PL0fmxcMwfzutsqvGt64Pqs+/znP48ZM2bgxz/+Mc4991y87W1vw1e+8hXcfffd4Y6QIAiiSZiq6Z78+yDLdRvjTIege2qmuz7cS7xiP2ShZLoVLcsLpl2gGucS+NgOv0WUEs3yzneD6+Y4Dtf5bQ+9jrsf34O3nLIQ7zt/hdmNNKSqC1V2oUvndeADF6zE8zv7ceufXp30t2rfQfc+uRe5vIErpnmWG17kJWeeeSbOPPNMAMDAwAD+8z//EzfffDN+9rOf4dJLLw1zjARBEE1BeWClTNPtNtPtIaCoZ6ZqutmUzFuk+CyAtAdDomwiFpiYtOHS+k5V0A2YjzHcNpDyW0Qp8VIf4P66K70fADY9sgu3P7wLZ6+bjw9etAqMMaXONVPWr1DGdt7JC/Hy3kHcfPdLMAoGzj9loTl+q0NsOeM5Hfc+uQ8nr5yNRXNmKBhBfeM66H7wwQexdetWbN26FQcPHsT69evxuc99Dqeddlq4IyQIgmgSHAspFdj4mYF07Tv2NKjRAxw8gePWqvvXdJc+79bn2Muy49gnKp1LULaP3CzRbxGlfX2u28C7mGxxIdA3OI43snm8eHgUr+0awFMvH8GZa+firy5dbWs9L5AKQc8NxR79jDH81aWrwcFwyx9fwY79Q/irS4+rmOne8vQ+ZHM6rnjT9M9yw0vQ/fGPfxxLlizBxz/+cVx55ZVIJl1/lCAIgnBBebERY8yURii4GzaTptvRvcRDNlQ1fjXdpc8LCFlcq2hMXoJHlehcenSrWZ7XxQQpooT11KQg/Hvh7D8yihd2DWD/kVHsPzqG/UfHkC8YOOmUhTi4fxiFbB4XnLII779wxaTmN1xAWTOccvx22qxEayaJ//nR0/GTTc/jtw/uxJ5DI/jQO05AT5n3di5v4J4n9uKEY7txzPxOJeuud1xHzjfffDOeeuop3H333fjud7+LVatWYePGjdi4cSM2bNhQ9bPf+MY3cM8992D//v244447sGrVKgDA66+/ji984QsYHBxEV1cXvvGNbxR9v6v9jSAIYjriZDGmIiPpNuiLOyOsCpkVtruXQHFHRy/4znRLizq75ZrCDYgn022+qiykhMttkUWUbQn/6/Ziq1l+3b20ewDf+fUzKOgcM1pTWNTbjrNOnI+Fve2YOb8DC960DHPbnZvChCovsY1XFZrGcPmZy3Ds/E784PYX8Icn9uCM43oxZ3nJ1+SBZw5gdLyAtzVJlhteJs0bNmzA3/7t3+Kmm27CbbfdhhNPPBE33XQTrr766pqfveCCC3DLLbcUfb4l1113Ha666ircc889uOqqq/ClL33J1d8IgiCmI07BmQqPaS/a0mkg6YaQLeBlcxxr4+OSdfv16YbtmJQXhwbF3DfR7xBdmPIOdS4sJm7O21IRpf+96FfTvfPAMP7Xrc+it6sV3/rEm3Djfzsb/3jVKfjgRatw3vqF6OlsQTrt7Fwun9KEVkgZojXpmmXduO4jp2H2zBbc8/he/HTzyyjoHAXdwN2P78bqJV1YuagrhDXXJ64z3X/84x/x+OOPY+vWrdi1axfWrl2LD33oQ9i4cWPNzzplwvv6+rB9+3b86Ec/AgBcccUV+MpXvoL+/n4IISr+rbu729sWEgRBNAhOGWklxY21u8BPGkOjw8smGcWC1Jhy3UHWKkPjWj7HfpcbNSqdS+y42ZagRZSwXY+upErWdbfvyCi+86tt6GxL4X+8b71ji/NqE95yuZRqVLmXVGJWRwbnrF+IznQSt9+3A68fGMYJx3ZjcDSPj11xfDgrrVNcB90/+clPsHHjRnzhC1/AySefjJaWlkArPnjwIObOnYtEwpzZJRIJzJkzBwcPHoQQouLfKOgmCGK6Emam2w2MMSCAXrVe4EJMyqTK/8eVxTcDZv++0LI5jsqYK66nGroQyATINJfjRRoRtIgSticNHKjZUVMAGB7L499/sQ2ppIZr3n+yY8CNGpOgcrmUasKQl9gxJyjAeesXYMnMVvzwzu3Y9cgIli/oxJqls0Jaa33iOuj+6U9/Gu5IQqanJz4rmt7ejtjWPZ2g/agG2o9qCGM/TgyPo8A5ervaq/7OK8MDY8gkNPR2Vm+vnB+ZwHjBQG+3/3X5QfW+zA5lIQD0zjQbbWQLBkaHsujqbMWMdPQmAIP9o2hPJdHb4T1ZNTwwhpakGW4ldY7eWZWPjZf9qI9OQMvp6I3w3iiEwNG+UfS0ptFbQbvslUyugOzIBHq62tCSrB4Gjw5m0c5K50Ulqu3H5EQBudEJ9MxqRypRPQw+eGAQdz62G1wA/8/fvxlL5lUuFqx2jmQLOoaGxtHb2Yr2EM5feVxmtqXR26bmuMC2Hw0ucLR/FN3tGaxcMAvrjpuLH9+5He84bznmzGmOAkqJ66OXz+fx7//+79i0aRMGBwfx1FNP4aGHHsKuXbvwoQ99yPOK58+fj0OHDsEwDCQSCRiGgcOHD2P+/PkQQlT8m1/6+kZj8Wnt7e3AkSMjka93ukH7UQ20H9UQ1n4cyhUgABwplLLNo3kdOc4n/c4rIxN55DUNR3J69ffldYwbHEeM6LLdYezLoYkCEgw4kjcAy7EiO1HA0YKB8RqBWRiMjOfBEwUcmSh4/uzoRAETVipSF8AR3fnYeN2Pw3kdYwbHkQjviwUuMDaRR0vBwJFsXskyxw2ObK6AowavmUEfHM+jNaEVzwsnau3HMd1ANq/jsMGrasOHs3nc/tguZMcL+Ox716E1waovdyIPXSsg5XCOZK1tHDQ4sgqfEtgZH89jIK8DY2qOi30/6kIgO57HUMEAH80hCeBvLlsNANPyfqRprGKi1/XRu+GGG/DKK6/g29/+dlHHtHLlSvz85z/3Naienh6sWbMGmzZtAgBs2rQJa9asQXd3d9W/EQRBTFec5CVRygCmjXsJnOUlcQlngmq65TJUanrjsIcsenSHoemusTFCiMAOIDsPDOMX976Kl/cO4vWDI9ArTE6zEzq+88tnkJ3QcfkZS7GsSoZbUq12Q7VHu/P6w/ueUV0E3Mi4znTfd9992Lx5M9ra2qBZM625c+fi0KFDNT/71a9+FZs3b8bRo0fxkY98BF1dXbjzzjvx5S9/GV/4whfw/e9/H52dnfjGN75R/Ey1vxEEQUxHTNeNyb9Toul2qQeeNkG3mHyDl/+P1ZnFZ7xk13QHcLpzHI4o6m2jKS4NI+h2q0fm1rb61XO/uKsfN976HGZ0pJBNMNz5ylEUcjpWL5mFNctm4fhl3VjQ04a8zvG/fvMM9h0ZxccvWoGFve7kO9U13earyuPvZf1Bkc29VDnWNDKug+5UKgXDmPxIpr+/H11dta1err32Wlx77bVTfr98+XL8+te/dvxMtb8RBEFMR8wWKJNvTJ7cEiou12XMNw2a4wghprjAyM6ePIatKx47n5+f5F6iupQy4lmIbp3DSicPLpdVDFx9rOMvrxzB/3fbC5jb3YrPvPckDAqBgWXdeGlnP7bv6se2HUcBAF0z0mhvTeHAkTH87X9Zi3k97a6PWLUnD9yyQQkzZA3zyYfc9xRyewi6L730Unz+85/HP/3TPwEADh8+jK997Wu4/PLLwxwfQRBE0yCK/sklNPvfAi239vsYzHRwXJ0bVSCzt3ZPY5WdPf2MBwGkAbJzpOqOhF7bp6tA5wIJNvUcD4LbTLch/GVbH33+DfzwzhexbH4H/vt7TkImk0R2Io/jj+nGaSvNRi9HB8exffcAtu/qx97Do/jIZWtw2pq52DvuXh9dK9OtOXw3qCTcTLdJWJaHjYTroPuzn/0svvWtb+Htb387xsfHcckll+A973kPPvnJT4Y7QoIgiCbBSQZib+zi96bl2jIw5s6NKqjkaRyXdKYYdPuVlxQz3YotA0NsiFIJXQAp5YGjuxbmMuj2kmXf8vQ+3Lz5FaxZOgufeueJaM0ki8uxS75md7XinK5WnHPSgkmfdzvZhW1y5USY3ShL61fQD6ACUWjSGwXXuvZ0Oo0vfvGL+Mtf/oJHHnkETz/9NN75znfimmuuCXeEBEEQTUKlQkoEKAIUwuzC51bT3ehUKtrSGCve/KOklOn2CWMQCF4EOGWx6hblmjAa43jRdANwpekWQuDOR3fh5s2vYP2K2fjv71mH1oyZo/RSH+B1olTNpzusbpSSMOUllOkuUTPTPT4+jh/84Ad46aWXsHTpUnz605/G2NgYvvSlL+Hhhx/GlVdeGc1ICYIgpjmOHSllY5eAuU43WaY4sp+qqVS0paIg1eeAgIDuJdzUzCjNFE7qQhhBMGQIAR5i0O1m/bBkRtUQQuA397+GPzy+B2esnYuPXrYGSZsft+wKWqs+QE523Y6wWmMqI8BTLreE+SSI3EtK1Ay6r7/+emzfvh1nnXUWHnzwQbzyyivYuXMnrrzySlx//fVk40cQBKGASgV3xQ54Pu+IXjKtUQdiYVAx020FL1ETNNPNQm4DHtUuKTqXKN4ItxNFQ5hFlNV00ZwLfP/WZ3H343vwlpMX4oMXr3LUgLux1/N63KtquiGQ9NnR1C3V5C1BkYWghIug+89//jNuu+029PT04Oqrr8Z5552Hn/70p9i4cWM0IyQIgmgCKhXcaQGzz140xWG3g46Con60bIMZYxAxtLiXmXe/RXCyuBWK50FRH2udS7vAcJbvppCyWhHl6HgB//fOF7Ftx1FcfuZSvPOcYyseMy9PTTwF3ZU03cKf64oXQi2kjKAQtFGoGXRns1n09PQAAObNm4e2tjYKuAmCIBRTKTguFjf61CP7+VRQKUucVMoKx+9e4g/7+aDS57gUAEVzrHVrR4Sm6a5xbKv5nL+2fwj/cdvzGBzN42/fcSJOP663xjpr1wd4LaCtFPSqaOrjav0hTkqjGH+jUDPoNgwDjz322KQv/PKfzzzzzPBGSBAE0QRUCs6K7iV+l+tBU1zSjzcu1eQlcWi6vex/J1iF/wcl8ky31ZhGdYMU15aBEMiUSTSEENi8dS9+c/9rmNWRwT9ffSpOW7ewZmtyzUXRodf9WqmQUZgDDb+QMsRlC8X1CI1MzaC7p6cH//zP/1z8uaura9LPjDHcd9994Y2QIAiiCRAVgsWie0nA6MiTe0kDR92VGomYmbzoPciD7kr7loSi6Y7oWBsBukHWhNUWRxhlEg27nOSUVb346GWr0daScrU6N/UBfiZbTossTiIjKKQMT9NNmW5JzaB7y5Yt0YyEIAiiiZHa3/Ln0Qwl2ziVy3ViOmi6K+lH7U8MwtbHThqP9RrEp9vp/0GJ+lgbitvYS5g1waq2HdyabMks+2sHhvAfv38Bg6M5fOCClbhwwyJPEzFmv65cvNfd+5hjYyrpkhJ2C/WwNd0k5zZx3RyHIAiCCI+il23Z74N2U/TlXuJvVXVBpazaJH/lCAMAEbAIcpKmW6VlYMRBkCEEUlo4Dhy13ESM4lMkU07y6z/twKyODP7pQ6fi2AWdntenMQZe44L0MtlFlQ6hRoUnYMoJsw08BFIkLwEo6CYIgqgPqj2ODpSF8qTpnvSRhqRSIxGZPeQRF4lWcqVxy6RMt8JhRznBksWAYWS64eJocmGGwLfevxMPPrUPJ6+cjY9evgbtLuUkTutz3+XV5fsqXHth2kVOWn+FTLsKBDmXFKGgmyAIog6olpEO0tjFj3tGWO2go6BWpjsOBxMoCvPDyHZGcayFtZ5EiJOdalthANixbwhbtx/C29+8DP/lrGMCBYHyeqwWoPrx6YZT0C2ik5fAIdOuAi6oMY6E9gNBEEQdUE37y8ACWwa6k5dMD/cSpxtbUBcYv6jSdMtOiKqI0k1CSiRCy3TXkEa8vG8QL+4ewPoVPYEDbtizwlXe47WQslIRc1TdHMN6yhWV5WGjQEE3QRBEHVDS/k69O6nIdLu5+0+H+6KAc/ZRSk6izuIHtgy0tkX1sYlSXmKEnK2tJvc4NJDF7Q/vQmd7GldftErJxMXNBM6zZWCFz3HrfA772gzrfJCWh2QZaEJBN0EQRB1QLSNdq1DM73KnrGdaaLqdb2ws7ky3z8/Lz6nOFEZ5rOU+DyvTjQpPgibyOv7tt88hmdJw+po5aEmrUdROKsqtNTKPou7y/DmPqJtjMehWfEIUC8Qp5gYo6CYIgqgPqskQNMaK1mHeF1w5g15OWDfeqBBCmIWUdaTplr7hfinKS0LKFE6XTHc5Qgj83ztfxIGjY7jszKXobPVXNOm4vklFuc6o1HRHEbCW1q/2jOABn/RMN6iQkiAIog6o6V5CloE1KWXVHNxLEMzv3PeYAmYq5ceUZ7qt1ygmWEVNd0jLd9J0/+HxPXjy5SN471tWYH7vDKXrc5PpLmXePVoGlmu6IyiiRIjdaOX1FsU2NAKU6SYIgqgD5CP4sNxLvKSaog5MVVGt6Cyo37nvMQUMmIvyElUDKltuFHCrMU1YEolyTffzO/tw6/2v4bQ1c3DJaYvBFXfD9CJVCp7pjiZQC2sSFlUhaKNA+4EgCKIOELJ9uWOWttTC3Pty5TJqIx0yGjPkrt29L8jkxS8icBFZOIWUkigmWEaoeu7JT4IOD2TxH7e9gIW9M/CRt64BY2xKC/iguCnK9SwvqejTLaLJdMN5/UEpJhMo0Q1Q0E0QBFEfiCoZreLjbF8LNl883fMaNOqulVVjYEXf46hQlulWHLVEOcHiIprAMZc38G+/fQ6MAZ9614nIpBNFnX/UmW6vVpGV3hZZpjtEy0Ao7qbayJCmmyAIog6o1pTCfpP3egP2U9DVoDF3zayaFmKr60qIYHWUxc+GEbIEqRXwgiEEUiEG3eM5A28MZvHzx/Zg/9ExfO696zGnq9Vct/UelZp4N0W53i0Dp2bPqxUGq4Yy3dFAQTdBEEQdIKoFi9Yr99Euzqt8oKGD7hpZNc1W1BfZmCCQChAyl5rjKBtS5BgCaFEUOeoGx55Do3jtwBB2HhjGa/uH0D6rFe0z0nh51wDef8FKrD2m27Zu84ArzXTDRVGuz+Y49iWWWsBHIS+RqW61F4io8fSp2aCgmyAIog6onum2e/h6uwELj90Ma3X3q2dKQYrz3xlj4CJaVTcXAAsQcDJr3CqDRvuywz7WqrK1Q2N5/O/bX8Cr+4agG+YxnNWRwfIFnVi5cjZ6Z7fhM5esRjo1Wb0ts9EqNeVuinI9+7M7yDuiLEIMS14i6ywaeM6oFAq6CYIg6oBqBXeBPKY9fqaRM921smpaDB7kImDQpDGGeZkkkmEE3RFMsKS8I+ik4a5Hd+PlPYO4cMMirFg4E8cu6ER3ZwsAoC+vY9zgUwJu2D3CFYd9ta4TP0+YMCXTHZ3dXljyElNeFZ5zTaNBQTdBEEQdUFVeEiAL5TU3zip092sEii2z68S9RAgRuJASANJaeLnOsI80V9AYZzibxwPb9uOMtXPx/gtWTvl7tQDYCCHTDRfnkgAquhE54WTZV8zS+x+ma0KzDCRpySRoXxAEQdQBVeUlLizK/Cx3ulHL6UELYL3oBwEzigmrm2RQGFjoqX8VjXH+uHUvCjrH5Wcudfx7tYw9F+ZETLn7i4vJqbfJrslkeUnjZ7p5g9cjqIaCboIgiDpAiMo3aZkp9ZOlrZZBd6KhNd01tMNempqooNQhM6IVeiQKKREPWMiYnShgy9P7cOpxvZjf0+74nqqZ7pA8wmtmuqtcz04wxqYUZ9aqUVCJ0/pVIIQgu0AbFHQTBEHUAQKiSqbbJIpuio2s6eY1tLuBtPF+xuPHIz1CItF0S529z51w39P7MZ4zcPmZy6q8y8zYO2WeDSGQCOEIMBeFlF7XWv7+qLs5hmEhqUJeNZ2goJsgCKIOkC4jTriyKKu0XI/yhqi8m8OAi+o3eG2SC0z4iAgL4fwgJ1i6wdE3NBHKOgxLZ+8n2MjlDfxx616sW96DpfM6Kr6vmjTCqHFO+EULIStcfu1JaUxURYhhTLi9ZvynO1RISRAEUQdUuzm5sSiruFwf2tIGjbnBIZBklcO7KJ8YIIZMpReGs3m8emAIe4+O4aFHd2M8Z+DjbzseZ6ydp3Q9UmfvJ3B8YNt+jI4XcEXVLHf185sLgUQIhahuLAO9bnL5tWdEfO6Ece1zCKSqXJPNBgXdBEEQdUCt4NjvDdFz0M0YRMRe1qoQtQopI9Z011M3PiEE9h0ZwzM7juKZ145i5/5hHLO8B50daWxcPQcH+rL44Z0vYmZ7GmuWdbtYojsMny3YCzrH3U/sweolXVixaGbV91bymBZChKbpriXN8SUvYVMLKaN8ShKG3Igy3ZOhoJsgCKIOqJUZC2R31yR3vVr6Uan3jsy9JCSPaK88s+Mobt78MvqGcwCAZfM68PazjsHKVT2Y2dGCha1pZCcK+PrNT+PffvccvvDBU7F4zgwl6zaEv6D34ecOYnA0j7+54via751kd2dbF7d+GUZjIbsTjlMWX5QPxiXlHSnDmDBUIgy7UNJ0T4aCboIgiJgp3ryrvMfvDdGXvKQB9SVyH1YtpGzCTLcQAr/csgOJhIa/futqrFveg64ZGQDAkbyOPDdH2daSwmffexJu+OlT+M6vtuGLV29Az8yWwOvnECjkOL57+3Zkczo++Y4TMbM9XfUzBue467HdOGZ+J45fOsv1uspP21JjHPXYnXAq2SF6L6ScfI1zAaQiDbrVZrrdXJPNBgltCIIgYqbUMrp6wOjLMtCrdVmDarrd2KtFremu1SEzCl7ZO4g3+rN425uW4ZyTFhQDbjgEhd2dLfjse05CrmDgO79+BmMThUDrFkLgjYFx3HLPy3hx9wD2HBrBDT95Eof6s1U/9/j2Qzg6NIEr3rTUlRa8UiFlqTFOGJlua50VziW/mm47jS4vqYdJZ71BQTdBEETMFIPuGgGjnwy0d013gwbdLgJc6QLDI9pCuZ44Y44Hth1AayaJDavnTPmb0zm1aM4MfOqd63CoP4vv3focCrox5XNu4Fxg0yO78MjzbyChMfzPD2/AP37gFEzkDdzw06ew88Cw8+eEwJ2P7sai3nactGK2q3WVAvPJGxPUI9zNOiudS0o03RFLM9Rnus1XCjRL0L4gCIKImVKmuzKaz2BRQHhKNckbb6O1gi8GuFW2VbrARLVpQiBSy7dyRscLePLlw3jT2nnIpKaKICoFWWuWzsLHrjger+wdxE2bXiwGr24ZHsvjO7/ahjsf34OFve342GWrsWjODBy7oBNf/PCpaM0k8M2fP41tO45O+ezTLx/Bwb4sLj9zmecsb6VMdyiWgdZrxacmPs4x+/GIQ5qhWlpWD5POeoOCboIgiJiRN7qa7iU+b4je5CXhtwYPA7f2fIEKUj3CY77JPvLcQeiGwLnrFzj+vVpm8/Tj5+K9b1mBrS8dxq+27HC9zpd2D+C6Hz2BV/YN4aqLV+GUVb1oTZfKx+bOasM/X70BC3ra8b1bn8WDzxwo/k0IgU2P7sLcWa3Y6JCZr8SkQkobQTzCa1GUl1T4u9/mOHIb5POF6DPd6q79Yqab9CVFKOgmCIKIGeEiSxuVprs0psbCbctsDcxz5tYvPEY9qxAC9287gOULO7GokhNJjbFdctpiXHjqImzeuhf3PLGn6nu5ELjj4dfxrV/8BS3pJK798AZsWDMXzOGYzGxP4x+vOhlrj+nGf/7hJdz20OsQQuC5nf3Yc2gUl52xFJqHaLOSpjuIR3jNdcpCygrnku+gG3K55mukPt2MhaLppkCzBLmXEARBxIwbeQmrYVFWbdleNd1owKDbrT1flJr1OJ0bZAHlRy9bU/E9zO6c43BOMcbw/gtWYnA0h19u2YG7HtsNTWNIaAwas16tn/MFjsOD4zjj+Lm4+pLj0JpJYtTSgzu1YW9JJ/GZd63Dj+82g+6BkQkcOJpFd2cGZ57grUFPpcvBr0e4G4r2kxXfIQCPTWHsHvkymI+0kFK5vMRaLiW6i1DQTRAEETNuCo7sj7P9ZNC8vrfRgu5iZrBmpruk9Q2bOD2KH3jGLKDcuKayTKOaW45E0xj+69uOx6LePRgay8PgApwL81WI4s+cC1z+pqU468T5xQC+5B7ivOxkQsNHL1uDWR0ZbHpkNwDggxetQjLhMVi1Xp003WH5XNstA53w59Jdwu2TG5W4LaSUE9xak/968amvJyjoJgiCiBlXmW7bTd5LSCJqLbh8PfJzQaOGiOFWwWitIWuMoRBRx00h4gm6R8cLePKlIzjnpPmOBZQSe7BabZipZAJvP+sYz+MwLMu7WsWt7zxnObo7W/DMq0dx9rr5ntcjKS/+DbMFea1CSj+yLnummccQsLp9CjRicAwXDCxsSVU9tpTpngoF3QRBEDHjxjJw0k3e5U3MTdOdchr1/uhWv6tF6NMdZtBXDbOAkuO89QurvzFkKZHhIVN73vqFtcdbAeYg9RBChJzpZpYGuvLeC6Tptl7jyHTXkrDluIAhBPJCIFPlfWQZOBXaFwRBEDFTfFxb5TYtb4J+3AXcyAhUrCdO3Eo5otR0c59FrEEQQuCBZw5g+YIqBZQWYUuJeIiaajtOa5DBo5OeXBXVJnB+9qn93OSm32S0hZQunYt0a6NzNWav3HKPicsysx6hoJsgCCJmXPl0y/d6uJsHCaYaK+S2uve50SjbClLDRsSg6X513xAO9mVxTgWbQDvFoYW0KwwRTZDhVPxbS0+uar1VLQM9rgNNLZ0AACAASURBVNte2Bqm80q19aPG6SCEgC7cBd1+nZOmMxR0EwRBxIwreUmNwi2/yy2nkudxveM20+1nP/qhJO2JNux4YNt+tGYSOG313JrvnS6ZbsnkoDt8949q9pP+Cp5Ln4ijCNeNcxG3ZeFzRvWrKM5C4nqFgm6CIIiYcdccx5J9+IiGm8G9xG1WTb4nbF13HJrc0fECtr50BGeunYdMunIBZTlhSImEEDBCzjRLnCaKsrlMHJluIYSvSmT7tef2yY1K3Ey4C9aF06oxGEIUpSZO8BgmnfUOBd0EQRAx464NvPnqKdPtIpgvp1F9ujmEq6ymfA8PeQvjKCJ75Pk3oBsc55xUW1qCkKULHOZOiFLTbT+iMgMd5vprFeV6XrPt2uMxON+4mXBLaUm7ZeuY45W/keKQV9U7FHQTBEHETNHurpq1mnyvD013M7mX1MKPNt7XeGSX0XBXU0QIgQe27cexCzqxZG6Hq8+EKSUqyjvUL9oZNtll2oigEJEx5jh583PdoTzT7XISqRI3RdQFa7+2JTQwxqrqut1ek80E7Q+CIIi4cSGNYDADCy9SgCBOJ1EUGqpCCFGHmm65vmgCp+2v9+NgXxbnusxyI2QpkYzFIsl0W/7s5YWUiZCz+VqFCUvxVz4KKWEtM46A1VWmmwskmblfM1r1oFvAW/fcZoCCboIgiJhx0/CGWVk7P1pkPze+xgm5rbG61MDKSUWlAjhVFBuDhLqWEnc/tsssoFxTu4CynDD2RBSFjHZYWQAsG/OEiVZh8qYi0+3F41wVrjTdAkhZ+zWjMeSFqHgtUaZ7KrQ/CIIgYsatvVh5Ns/NcuFVXtKAmm63LeDt7wl7+6IspBwdL+DhZw7gDI8FlGEe6ygKGavBI1g3Y3C2n/RRSwHb5JhbhZixFVJW+Lu0C0wWg24NEAL5CpmABmtqGwkUdBMEQcSM26BHYxEUUnocUz1Q1E+7KaSUnwl5A0VR0xx+2PHo82+goHNP0hKEHBBF3dxlqrwk/CJOeWzLT6WgmW6jWAQacIBe119jEmZY53VKK2W6UcGvW1gZcCqknAwF3QRBEDEjPEgjvGitfXXFK47Jx4djopjpdvFe2SEvbPeSorwk5KCjoHPc99Q+rFrS5bqAskR4+v0oNNV2yu375PrDXiccJCZ+LRiLQbf1GnUhZa3zQdoDyky3xhhSmuboYFK6JinqtkNBN0EQRMy4fQzrOdNtvfppjtNIeJVy+NXGeyEqy8B7n9yLw4Pj+OAlazx/NsynGlFoqu3YM93cknxEoelGlQmq3wlH5M4vFrXOh4I1rpRtu2QxZXmgXnr6FNJgGxQKugmCIGLGk6bbTyGl5w94c0mJG69Sjmrtu1XBLeeGMDO9Q6M53P7ILqxfMRunrJ7j+fNharqj0FRPpvQUKIoW8LBrsMv2oG95ifUBOf5660ipC/Octu/XjGZ25SyUB93WTJiCzMkk4x7Avn378MlPfrL488jICEZHR/HEE0/g/PPPRzqdRiaTAQBcc801OPvss2McLUEQhHqEy0YYGmMoCPe57lL2yf3d28l+rd7xnumu3L5bFW47ZAbhNw+8Bl3neN8FK3x9PszxGUKYhXYRYd8WGQSHr+m21ldeR+nz1Cp58UdXD+C0/oqZbptdoEQe4xwXSNsOt5c6i2Yi9qB70aJFuO2224o/33DDDTAMo/jzjTfeiFWrVsU0OoIgiPBxKy/xmukOUtA1XTXd8CHT8YNb33C/7DwwjIefewNvPX0J5s5q87WMcJvjRJvltD+9iCpTXMkJx/91Z34itky39VrpfLA7l0iSzJzc5LiAvaKA83gkMvVOXe2PfD6PO+64A+9617viHgpBEERkuG0iEYWmGz6sCePGq5SDRaDp5kIUg6gwlv2ze1/BzPY0rnjTssDLU70rpKY6isY4Evs5W3T/CDlTXMvz3c91B1s3zXjKKJ0LQU27QBSdS4qfYQxpjU0ppvRi49lMxJ7ptrNlyxbMnTsXa9euLf7ummuugRACp556Kj73uc+hs7Mz1jESBEGoxq0UgaHkC+zlsa0fbWlDBd0es6oaYxAeZDp+ECEGHI+98AZ2HhjG31y+Bq0Z/7fxsAopS90oFS+4CvaJVFTrV57plppuROv8Ulq/OXF1Oh8MYX73lGe6YUlMxgv6JJtGORGJfupQ39RV0H3rrbdOynLfcsstmD9/PvL5PG644QZcf/31+Pa3v+1r2T09MxSO1Bu9vV5tnAgnaD+qgfajGlTux/6+UczMJNE7o6Xq+7TxPApjOfR0z0DCRUSnjecxMZZDr8v3S4YGxtCa1NDb0er6M0EIui/zI+NI6Ry9s9pdvd8YncBQTkdviPeF0cEsEgzonelP+lGJ7EQBv31wJ1Yt6cLbz1sJzXZc/ezHvqMjmNmaRm97RtkYxwsGBoYYZne2oiMdTZgxMTyOAufo7WqHMToBI6djjs/j63Y/ciHQ3zeKzrYMZreli78fzhUwNjKBnq42tCTdGxcaXKC/fxQAkElors9nlfT3jaKzJYne9snfRaN5HW3DDHNntqI9NfmYthcM5IeyaO9oRYc1Cewfz6OtPYM53e1IRqjtr3fqJug+dOgQtm7dim9+85vF382fPx8AkE6ncdVVV+ETn/iE7+X39Y0WNUZR0tvbgSNHRiJf73SD9qMaaD+qQfV+HB3Pg+UKSIwXqr5vRDeQzes4zJ0zTuUMFQxkCzqOcm/2aWMTBeQZkJ7QXX/GLyr25WCuAEMAR3R32evhgo4RneOwwUPLJg5P5JHSNBzJGy7e7Z7f3P8a+odz+MSVJ6Cvb7T4e7/7MTueRyKvg2XzysaYNTiyuQKGDI6JiAKukVwBBSFwpMDRn9eR5xxHfNzzvexHIQSyEwX053WIsVzx92PWddpviClyjGpwIZAdN4+DoWmuz2eVZMfzEBMFJLKTv4vkd88wF8iWXTNCCIxPFHAwr2PCCsi19gyyYzn0efzumQ5oGquY6K2b6cfvfvc7nHvuuZg1axYAIJvNYmTEPPGFELjrrruwZo13H1KCIIh6pigXcfHeWr7AU5ZtvfoqpPT4mTjhLt1fJBoYIMI1RfQqeXHDoYEsNm/dgzedMA/LF8xUsswwimbjcN+wyyJ4RHpyZnXcrNAF3ndHSsSoha4kLStwyy7Q8TNS1136ZFy69HqnbjLdv/vd7/DFL36x+HNfXx8+/elPwzAMcM6xfPlyXHfddbGOkSAIQjWlG7SLjpSTfIHd3M6sG5/HAKThNN0QSDH3IW4lLa5KeAiWfL+8bwcSCQ3vPm+5smWGMcGKyifbjn3yYAgxqYFLmDgVNxf3p9dCSqmpjrix0KQxVDgfdGufVvouyWgMIzov1ptwIaCRZeAU6ibovueeeyb9vHjxYvz+97+PbTwEQRBR4MVhxE+m288tryEz3R7eb/dXDiMwFMWOiOqW+fzrfdi24yjefd5ydM1Qp78OA24FXnEFjoYAWiJKFcviZjt+M9124pIhMFuTITsFIZCucjwzmoZhYSDPBTIJBh6BT30jUjfyEoIgiGbEyw1axhFulZ5+G7Q0nE+3x8fxlToJqsLL0ws36AbHz+99FXO6WnHRhsVKlikJ46mGEXk3ytJEUQhhZlmjynSDTb0eRWlMXpGfiU1e4vA7aReYrDKojPU3KTHhiied0wUKugmCIGJEeLhByyDOKRPluOyQuw7WA8WssoctrdRJUBVeO2TW4k9P78fBvized8EKpJJqb9vhyEtE6B7Z5cjJgyxbjSroZ0ydphuTgu6Y5CUOkzDdnM1UlewkGEPS5tcdpk99I0NBN0EQRIzIcr4wMt1+MYvSGiPVLfeFlxglbE23DMJU3GB37BvC7x/aibXHdGP9itkKlliOs5wgCF4LW1UhbEWcUTXm0RyuxyB7Uw47PnnJ1Mmobu3TWo5JGU1DjgvraQM1xnGibjTdBEEQzUhJ0+2ikNJ6dZuhFT664qHBNN1eW8DDRSfBwGOSE6mAgd+TLx3G/9m0HbM6MvirS48LpSgtjLjIEALpiL2ZmeVIo8sizqjW69hoyV8BM+og0w2Ha79gXSe17A8zGsOYbh4DwyqkJCZDQTdBEESMeJOXmFG02yx0oELKBom6ZYDrJUgJ+4mBikz35q178cv7XsWxCzvxmXetQ4et+YpKVGu6hRAwYtAkT2qhHmHQqjlMgoPIupg15Y0t0+0widAtr+1aYyrpujmESJBziQMUdBMEQcSIvF+7uclKX2DXmW6fuspGynT7CXCj0nT7iTk4F/jFlldx75P7cOqqXvzXtx2PdCq8vK3qY81hHpSo5B0SuTa9KC+JaL2WZaC0ykOAAmbUaSFlwWr/XiuITlmONTkuwCjT7QgF3QRBEDHixTIQEQXEjRR0+ylaLPohh+Ve4rM5TL5g4H/fsR1Pv3IEF21YjPedv2JSm/cwcNLwBoFHLO+QyOvHEIjUrtDeaMm+Rt9rl5ruOH26HTTdbuRCjDFkrCY5aSEid7BpBCjoJgiCiJFSEZu7OxRzaMZRcdk+s62NZDrgt/uhlycGnsck1+FhSMPZPL73m2ex88Aw3n/BSly8Ua01YFRELe9wWn+UwZ5TUW6gQkrrNepJi339k7bF0sm3u9ynaU3DeEFHKuKOpI0CBd0EQRAx4kVeAutGFrZloGz4YX9kXq8UCyk9d/8LT9Mtx+R2SIcGsvjOr57BwEgOn7jyBGxYPSekkU2F2Rx0VGBELO+Q2OUlUdoV2oubE7YA3O9lw2xPYuKgXOPvxi7QTsZ2IZJ7yVQo6CYIgogRr/ISp7bTFZft07arkfx1i04hHj/nZfLiFSHdK1y89+jQOG74yVMAgH94/8lYsWhmKGOqhGw7rgp5bsal6TYEkIpQTCwz+naBSbBCyni9nMsn3NK5pFpjHDsZjRW/zBrnWyQ6KOgmCIKIES/uJfJ9Ycki7OtAgzTXMf2AvWcGvUxefI3JpWXglqf3Izuh4/q/OQ0LZreHNKLKqHaqMYQ54Yg6cCwVMQokWHRrd7TxFP6vnLaEhpQWX0UFK5s46NydR7dEY6zYLj5O28N6hYJugiCIGPHavU5jDIUpvsCVli3AfAQg8l4Z9q1fZtSC4LUFvEQDUAhpA92GXLrB8fBzB7F+5exYAu4wMDxMOMIiDk23/YoMMlltT8al5jYpv/YLwrQL9PLkIqMxGA0wYY8DcnQhCIKIESlFcIuXzGQQTTdC9urmQmDfRAEjeT3wcnzZIoboXsKFcDUR+MurRzGSLeDc9QtCGYcblFsGxuRaYV9llBnWYmbYdrE0whOiStifcsHSyLvVc0ukrpvcS6ZCQTdBEESMSE9ft5lBr5ruIPe9MDPdhjADtKxuBFqOCJDpDtO9xM1E4IFt+9HTmcHaZd3hDMQFqpvjGDHouVEW5EaZK67YaKlBA87yCbcuhGs9t6QtoWFJZ6vnYL0ZoKCbIAgiRrxmxZgiWUatdUCxq0U5sgAyrwdTVkv9tFc0W1MT1biZCBweyGL7rgGcfdKC0L24a6E06LbkCFFjX2WUQb889+yn0XTJdHMhoHPhWs9dXAZjmJFO1r3zURxQ0E0QBBEjXjO1mq3Qyc2yfclLIrhZyixzPmC6mcNfkMdsTU1Uw108YfjzswfBGHD2uvikJZDnh8JJHBfxeEzHJy8x4bYzKegTpjgpXfui2N0z1agbU4dQ0E0QBBEjXvO8rNLjbAf8+gVHpekGgILBAwV8QTLd8LH/3SBqTAR0g+PPzx7ESctnY1ZHJoQRuEelPaQQwtJ0xxulRaklLnY3Lct0Nyr2a1+3NsSrvISoDAXdBEFMG4QQOJQrIGuEZQanHuGxENDpcXbFZQctpPTxWbfIIyQshwQ/CCFM/bRPTTdC0nXXmgg8s+MohsfyOCfGAkqJymMt1flxxGjFaygGu0JtyuSt/ptKVcJ+PhS4zHQ35rbUIxR0EwQxbeAAJgyOiUYKuj1+EcubOa8RJgkhfPsFRxJ02xbu17pPwJx9+Gk3PbmpiTrcTAQeeOYAZnVkcOKx8RVQSlTaQ/JiN8r4CikTMdgVlnc3bWhNt+180K2nFuS3rQ4KugmCmDbIFtR6mLoIxXiVgLjNdHv1/55EBD7d3GaVqPtMN8tAx1/XTWsZYWxklYnA0cFxvLCzH2evm4+EVj+3YCWZbmshsWi6rd0dR8Bf3t20oTXd1qt8AkXSErXUzxVPEAQREHnTNxon5vZ8g/aqRQ7m0x2ie4lVcJfSmG95iQyY60nTLZdXKfZ78NmDAOIvoJSo1O/LSW+cmdE4vKHD7G4aNXbfcZ179+gmqkNBN0EQ04aGzXR7eL9TM45Ky4XvQsoI3EusYCWd0HxnukWAIE9zuR+9Um0iYHCOh549gBOO7UHPzBal6/WLyiMttz3O5jix2BVOQ8tAw/o+9WoXSFSHgm6CICJjVDcwVAjWDKUastqeWy4KjYDwWHTl1r0kiLwkGk236fCRTmgo+LSsCyIvKWa6FW+k1Ig7BX/PvtaHwdF8rB0op6BQ225Y53IcYVpR0x1LpptNtgz0OdmtB+S4ZRElyUvUQkE3QRCRMWZwjBrhBd32QLtRst2e5SXWa61gMcjmqyyuq4R0+MgkNHOS5GsZ5gh9tYGXy1C8lfK4OI3ogW0HMHNGGuuW9yhdZxCUupcIM+iNw7mDMYaZqSTaE9GHNU6Z7kZFHrl80bkk1uFMOyjoJggiMrgwb8xhaYV1USrOaxRdt5+OlGCsZmZSSaY7TJ9ulDLdsGXWvC3DxFchpYO/sgrk4srH1D88ged29uGsE+cjGUNgWAmVx5r7dJJRRVcqgXQMxal2Tbd0DWrUWFWOW9ZZkLxELfVz5RMEMe3hEEVLtTAwRCkz0zCZbo+PopnlQ1x780Tx/UHGFhYy0y2Dbj/HK0ghpfyc8kLKYvZ9Mn9+9iCEAM45qY6kJYq1xzLT3Wwwy73EnkyIR2SjCGZuD9kFqoeCboIgIkPek4yQAmJDCDPTxVhDBN3yRu31tsY8aLr9UJIchLMP5cRLY6Z7CWP+HEx4QA1xGK4TxUy3bVScC/z52QNYe0w3ertaFa8xGGrlJdU7cU5XipKvoFaddYD9ekqRnls5FHQTTY8QAgMFPbRAkDCxZ7jDkH4IIWBYhVRJ1jjyEvjIipU343BCns6+5CWMWRKWcOAoeVkzxpBkzJe8ROrh/WbzGZjygtti9t02pOdf70P/cA7n1lmWG1DnyS6v72bMdMtjLYRtPzbwfpBDJ2mJeijoJpqevBAYLhgYa6Auho2IsNmzhTHBkYFcwgriGiHTXcvTuRLlzTicCJpxYwhPX1IemKaYv1bwhYCWZhpTr1uXhZn2UT2w7QA621JYv3K22pUpQFWmW17fiUaONn1iL8pt9Ew3KOgOFQq6iaZHBgC5UFrTERL73tVD2NUykE8whgRjDfHkwu8N2osswu99k4Wo6ZaBqZQiJDUG3WOBrRACeS6QDvAIXAvBvUTYijQBYGAkh2d29OHN6+qrgFJSfMoS8HoxHDL8zYJWtF0sXTSNvBvkdwbJS9STjHsABBE38vFyzuCmvpZm96Fgn9OEERDLm34SprxkzAri6vl4+pWAMDeWgbb3+iHUoLusADLFzJSzLtxblOnCvHYzQYJuxsAVT7ZlgWh2QsejL7yBLU/vAxei7gooJaoy3fZJb7NRzHSL0qSjkfcCZbrDg4Juoukp6YwFDGEGbIR67BnFcILuyZluNMDxFA5SBDdojKEgque6g9oyMhZm0C0z3ebPMqNWEAIpl3sjx83tD5LpDmNicWggi5f2D2Hzn15DvsCxbF4HPnHlCZg7q03xmhShSNMtz8Zm1nTzECeqUcLAAEYe3WFAQTfR9NgTXTnOkdQScQ5n2lLS8bJQihzlMs1CSvNuoQuBZB3nnEqt2j0WUnpQA/j19ghXXmJSlJdYrwUuAJeXX56bTzFSATXdXDrIOCyHC4EDR8ZQMDjaWpJoyyTRmklOkYnk8gYef/EQ7v/LfmjtabS0JnDG8XNx7vqFOGZ+p+/xRYHqTHczupfIa0zYOl3V8xO2WjBmBoeNvA31CgXdRNPDbW24c1ygPe4BTVNkdjOlMegh6OelXRljrJhtq3ddt195iRtNd/CCrtrFmn4pl5fIpxNeil9z3JSWBAkMpK2fvUHR0cFxbN89gO27+rF91wBGxwtTPpdJJSYF4fuPjmI8Z2Dh7Hacv24+li/sxJIZLb7HFSXFvRfwUBcnvUEH1IA4ZbobOVxNW+5FhHoo6CaaHqnBTGmMiilDRAaJKcaQQ+Xsol90y7kEKElKwijYVInfGzSze3xX2IelLLq/sYV5y3Xy105q7r26hRAoCIGOGoWJL+8ZwC+37EB7SxKd7Rl0zUhjZnsanTPSmNmeQUt7CrkEw1N7h/Di62aQfXhwHADQZbVrX7N0FtpbUxif0JHN6RibKCBr/X98wvx5/YpenLt+AVYumok3cnpDSSxUZbq5bdLbbMiz0GpG2fB0pyk0DAvas0TTI28WGY1hSOfFnwm1yPmMLJozFH8B2bvhaVYntXq3DfQbGMsMLa+SWQy65W68wP0iJ7r2AC3FGMZd2nbmrQlHpkrL73zBwI/uegkTBQOaxvBG/yCGxnLQbdqmrlmtWHZsN1564RDABVYvmYULNyzC8cu6Mb+nzVcAySGQZPXnUlKLoI2QjCbVc8PmVsNtz0yadFcQNaCgm2h6ZGe8jKYBwkCeC7Q0690jRGR2M2k9izUCeiyXYwiBlC0ISzaAbaCUb3jVXcvCwzwXaK1wrgZpjgPrEfOowWHYniCogjtYy8nj5WbSK59IVSuivPPR3Tg8OI7/8f71WLusG7D293hOx9BYHkOjeQxOFDCR1HDJ8fOwfF6HEks/IRrLi1dVI6RmT1bIOougT5iI6Q0F3UTTIx0uMpp585ngAi3NKEwMGVljJKUfKosp7d0oJQk2feUlUss8wTlaawSKfu/97UkNI7qBcYNjRlLtBeEUoNkdTDI1IpY8LzVBcuJg3xjuemw3zlg7txhwwwow21pSaGtJYX5PO3IGxxu5AuZkUso8tJ0mFPWOikZIhhCBilobHVlnMR003UR4NNKEnCBCgVuZPM1yQshz6kwZBjIYkVlTlVloezdKSUNkuq1Xr0GalENNVJm5BJULpK2nEmF0auUO2WAZsLlpB5/jvKI/txACP7n7ZWRSCbzv/JVVl6N5WKcbijp7JUuLjqBONYblsd7Mvs4MzHTCiXsgRF1DQTfR9HDbhZCxiinDcm1oZrgQ0MDMfa1Yb+3UmCPJzJsgr+NjGUQC0qJpyHNecWJR3hnRK4wxtCc0THChXBvPMTXTnWTmeVGrmNIQAjoXSFfQcz/y/Bt4ee8g3v2W5ZjZnq66rJTGkNY0jFqNsYJSnEQ1WNgdNOge0c39155s3pBCk772PiVjRHPQvFcIQdgyUzIAyGhmoObWRYFwj8x0M8aQUCwvsXejlEipST0XUwZ5FC3rDiYqZKJtlsG+aU8kACEwpqvNdjtluhljSDLUtJPMW393ynSPjhfwyy07sGLhTNcdIDuSGgqcF5cbBLmIRkv4BmmExIXAqG6gNaFVnAg1A5p1/Ov324aoB5r3CiGISU06zFfphkDWgeoxM90mCcXSD6fGHLJgs5513QLCd4SWtiRREyGeqzITnFUoMRFCVNQ9pxhDocbm5Li5z5yKKH/1px0Yz+n48CXHuS7qa0to0BjDiIJtLH6fBF5S4zBmFdt2Ktb9NxrMup6pkJKoRjN9NxDEFMqbdCQtzTEF3erhwt6BMKRMt+1GlwxBO64aaTDmRwLCGEOLZhZTOkkjhKJirvakKWNRVesgH8E7STBSmik7qib1yHOOlDXhsPPK3kE89OxBXLxxMRbNmeF6PJolo8kalaU6bpEhV6O5eDCbk44XhBAY1g2kNa2ixr5Z0Bib1N24ufcGUQkKuommhpdlSJmVQctRMaVy7NnNMDLd5Y05pA90XctLAkpAWhIadC4cs/lCUbatPaEBTF1BpZwgVcp0C+G8PbCCPNmJ0o5ucPz47pfQ09mCt7/5GM9jmpHUIIQIvI1FeUmgpUQPgz/LwHFu6us7k1pTNsWxI3XxQa06iekNBd1EU2NYr/Z7eItmBjL1nCFtNEquDuaOTiguctQdvKRlO/j6lpcEDLotOdSEwyRR1WYnGEOrxpBVVmxYORssn05Umijpwpwol0tL7nliDw72ZfHBi1chk/Yuc0hrph55VA+2jX7daOLGbyHlsG4gqTG0KbJbbGTKLQMJwgm6UoimppjptoU+MotGEhN1lGvnZZGjKomJvRulnXq3DQyajU4yU7vuWExpm+QEpc3KqKu4JoqZboe/2b26nZASF3um+/DgOG5/eBdOXdWL9Stm+x6XioJK3qjOFT6GO2Fw5AyOjmSi6bPckMdcCKsrJWW6CWco6CaamvJgEFaXO8ZIYqKScu28aq9uDueuiQnGarphxAkPGBibum7T1q88Q6tK0w0r6GaMKSmoLEm6pv5NszLglY5ZjptdTaWntxACN29+GZrG8IELq3ty10JFQWUzZbqHdQMaY5hBWW7Adsy5NZOmiQjhBF0tRFNTynSXKOm66zdYazR4maRAZdAtNcDOmW5TQlTPvutBb80tls1l3inoVnTf1xhDa0LDmAKJSWmiO3VwMqCumOm2pCUyoHno2YN4fmc/3nn2sejubAk0Lo2ZMokgBZXlk8tGgdm0yG4ocIFxLtCR1BquaDQs5DE3GrA5EhEdjfbdQBBKkY4a5VmJjMaQpyY5ynByiYEieYlTN0pJkpmPfOtV162iZXiLlWks706pMtMNq6CSCzPYCkKtwDSpMccOkUII5LnZIj5fMHDz5pfxoz+8hJWLZuL8UxcGGpOkwyqo9JvR5wEsIOPGy1Ed1g0wAB1NbhNoR95DOElLiCokXbyHIKYtlYKe1QEamQAAIABJREFUjKZhWBjmTd4phUp4olzGI23yVGS6nbpRSuwZ9VQd3gqFCB50J5jppT3BOWbCFgQpjrpbNdOmb8zggQrnOEyJSKWhpRjDmFVka8+i5q1i3IGhCfy/t7+A/UfGcPHGxXjXucuRUNSURRZUjugcMxLeHTmEKLnmNBKMMUC4m2gYlstLe0JzvOaaFXkG1nMHXCJ+KOgmmhpewS/YXkyZoWROYERZwWrRWUTBsmWC1+kw1XLDiBtVo2pJMIzofFKgKhQ/ymSW/GLM4FMCYi/wGoFpqamRQNr2npzB8frBEfx604tIMeCz7z0JJx7b43NrKtOR1NCX131NuFU8uYgDL5ruEd2AAJq+GU458lTlCjrBEtMXCrqJpqbSTTLBmOkKwTk6HcM5wgtFSYFtX6vy6q6e6ZbvCbyaUBAQ0Fjw0LjFejKT4wKtiVLQrfrm357QMKobyBocM3wGXbUC05T1twIXSFu7Zjibx28f343+8QJWzO/ERy9fg5ntaV/rr0VbQkO/VVCZ8ZjRFwodY6LEraabC4ERnaNVY0WnGcJEJhSMsiZdBGGHgm6iqeFCIFXh0XRG0zBhFY412uPiekNqXe17ManIIcapG6VEY8x0MKnXTLeirFjGKi6c4BytVqAoIMAUBPTl60lant2+g+4KT5ckKcYAWzHlC7v6cdOm7Vi4bBZOXt6D81fPDfV6lB0q/WT0p3ume9TaJ51JCh3KKZ4monF1/UT40JVDNDXyUbcTGY1hTDeL8FL0HRoIJ0lBwmoFH3RS49SN0o7q7pcqUZWN1hhDRmNmMWVKwQIrICUmw7rp8OFH08srOM3Y15FkQP9oHpu2voYtT+/Hwt52XHz6EiztaotkAtyRNDP6Y5YPtVumc7wlhMCIbiCT0IrFu0SJSQ5YDfi0g4gGCrqJpkUIUTUzVdJ1c6Q0kpgEwWk/J8CKxyDI3nXqRmknySo3W4kblbZ+LZqGQd0oBsOqsujltCc0DBfMgNSPrpdDIFUhAy+EwKv7hrB1Tz/2HR3Dqy8dxVtOWYi3n3ssBg0+pRNlWPgtqOSoz4LdWjBWO9OdNTh0LjArQ2GDEwxyR5JlIFGZurh6zj//fKTTaWQyGQDANddcg7PPPhvbtm3Dl770JeRyOSxcuBDf+ta30NOjvnAmLPJcTdtkIhyEdZOv9Kg7xUy3hhwXmBH56NRjCIGcguYmfnCSFJT01v4ypqVlV8+cJhnDuGX/WE8yISGEUt11S4IBBYEJg6M9mQhF0w1bQDqm+wy6HZ4u6QbH1pcO449b92LXGyNYfmw3Tl47Fx87bwV6ZrZiqGAABp/UiTJsZiQ19Od15IVpU+gGLgDWgPoSZvs+dLpGhBAY1jmSGkNrA25fFDDGoJFlIFGDugi6AeDGG2/EqlWrij8LIfAP//AP+PrXv44NGzbg+9//Pr797W/j61//eqzjdAsXAgdzOtpzKvwZiDBw6kZph1mP7KdLk5yhgoGRoSy6Yli3Y6a7aOcXbNkGBDJVtMsJjUHowTPqoaCw8C5tTRInuEB7SIWUkraEhsGCjgIXngrqyp8ujWTz2HLvy7jjzzsxNJrHvO42XH3JcVi3eg5GBcfMVrNY0nzaxCJtxNKe0DDATFeYTNqdnEK1Y0x0sIqVlHnO0V8wkOccPelkXU1c6w025T8EMZm6CbrLee6555DJZLBhwwYAwPvf/35ccMEFDRN0M+tf3uB0/dUppXbUlY9QRtMwrhuBLNLqBV0IsJgyvlxMLXRU0ZVSCAHDRaYbCjLqqpFbrWpEcpI4YS9ODWlz25MaBnXTs7vLg/SqYHD0DU/g+X1DePbFw9h5YBgGF1h7TDc+8tbFOOHYbnPiYHCM5jgKXCChAXkuItcRey2orCVXq2eKNYC2/3MhMKQbGNY5NAA96STaSctdFc2qU2nAU4CIiLoJuq+55hoIIXDqqafic5/7HA4ePIgFCxYU/97d3Q3OOQYHB9HVFUeuzhvSh7jAOcIxtiKCIhPY1UKGjGZmgOxWbI2KzPQaDgFw2DhZ46mw8+NWsFMtmJbr0QXq6lqUobHKeUBrQsN43sxAixC1pUnG0KIxZA0DXanKV5AQAgeOjmH7rgFs39WP1w6NYMVxvdi7awCd6QQuPX0J3nrWsWgru7bsXt2GMAtho5SWSLwUVAqofXIRJfIclJfiuMHRX9Chc4H2ZAKzUom6mrDWK8wS6tCeIipRF0H3Lbfcgvnz5yOfz+OGG27A9ddfj4suukjpOnp6olflZoeyyBsCC3s7Il/3dKRX8X4cyekYGRnH7K42tFa4oXIhMNo3ita2NHrbMkrXHzXDA2PIGRwzu9vRViVQCoP+vlHMbEmit71l0u8H+0bRnkmid0ZLxc9WY0I30D/I0NvRgs6Ms22HzjmG+8fQ0Z5Bd6u6sDvo+Zg3OAYGxtA9owVdLWosRzoNjomBMbS0Z9CWYJjVlsHstnCmGiybw+FsHl1dbRgYzuHQQBaH+rI4PJDFoX7zdd/hUQyO5AAAC2a349xTFuGYFT046fK1mDezteKyhRAY6h9DWyaJtlQCbSMM82e2oTXi8xYAxvvHkElp6O2oPF5Y51lf/xi6FZ9nXvB7TibG88iN5dDV1Ya+8TxGczo6Mi2Y155Be7ouwoRI8bsfs0NZjBUMdKST6O2sfr40A6rv2dOBuria5s+fDwBIp9O46qqr8IlPfAIf/vCHceDAgeJ7+vv7wRjzneXu6xsFj1ibO57XobWmcOTISKTrnY709nYo34+juoFsXsegITBaJYtWmCjg0EQBGMsrXX/UDI3n0dKWxpG+0UBtvL0ihMDIRAFaroBEtjDpbxMTBejjeSTHCxU/X41xgyObK2BI58hV2CYhBMYnCjia12GM5nytpxwV52OeC2Qn8hgsGCgo6u4nhEA+V8DBiQLGDY6hvAExpmabAWAir+P1gyPYeWAIB4YmwNpSePrp/ZiYKNWuMABdHRnMntmC45fOwnGLu7Bm2SzMntmKcYPjcK6AwngeR/LmZyrty/xEAX3jeQxrDOM6xwgXGI0h25rLFZAVQHqien1OwTqeQwVD2XnmhSDnpPwufCFrfsd1JjV0JBPIDo0jq3ic9U6g/ZgzrzvkdBxp8nquMO7ZjYKmsYqJ3tiD7mw2C8Mw0NHRASEE7rrrLqxZswYnnHACJiYm8OSTT2LDhg34xS9+gbe+9a1xD9cTScaQ52Ja6IGnI05dEp3IaAyjDd4kRwhR1LBH7VktH7s7ucRIr26/VOtGKZG+z3qdFcQK62G+ynOKMYYWzdQhm7/wvywuBN7oy+K1A0PYeWAYr+0fxv6jo8V6u2MWz8TaeXNx8emL0d1mBtmzZ7agu7MFyQoToFrFy3ZSmtk8iXOzSDSuay9lNR2qdf3L49mI3/VyzBmNoTuVpG6TPpH7kfYeUYnYg+6+vj58+tOfhmEY4Jxj+fLluO6666BpGr75zW/iuuuum2QZ2EgkGZC3dInpBvwinu4YDl0SnchoDCO6QKGBj6Nh/3/EQXe1yY1p5+ffxrBaN0o7ZldK36sJBXkYVJ9RLRrDqLWxfpe9+40R/PDO7dh3ZAwA0JZJ4tgFnThl1TIsXzgTx8zvRDqTxMGJPGank2h3mal3U7wsSTJgTJjn64wYC/hSlvtNrSZZxfM8spGpo1VjmN+SQirGyc10QB572oNEJWIPuhcvXozf//73jn875ZRTcMcdd0Q+JlWUioHqq4CLMBEOXRKdyFht4ie4gEvnsLqD2wLtoBZ9ntddJQOYYOaEwO9ThFrdKCVBg/swUO1eIrG7fHhdtm5wbHpkFzY9shud7Sl8+NLjcNziLsztbpty/OQ55WUy4yUwTVmNRoStUVUcSPcbXVRvfBNGYWxUMMYaNqFQT9AuJGoRe9A9nbF/WRP1h+HyMXdSY0hqzGwso0h7GzWGLasaW6bb4W8JK7AyfH4ZmTaAtd8nW8HXk0SoGHQrHk6CMaQ0DQXuza50z6ER/PDOF7H38CjedMI8fODClWivUuCpWb7gXs4nDnP/uxmXXeKQ1uLNdMPSbLdWufxlI7RKzbaI6Y889nQGEJWgoDtENOnbWWdaUsKEC4GEy6/HFk1DtoF13TIrmUpoGIs8023iNMGxe3UnfWW6q+u5JVJ+UksiECUySAtjOK0aQ4G7i+h1g+Oux3bjjod3ob01hU+/60ScvLLX1XpMTb6HoNvl0yXYkhaapcmPiwRjSDCGQo3tbORMN6EGeezpHCAqQUF3iDAr45SjTHddUqt9uB2pk/XSErqekJruloSG4cgz3TK4dJaXIIDkpVY3Som9QU41iUCUlOQl6sfTktAwrBs1ZRz7jozih3e+iN1vjOD04+figxetwoxW9/aF5hME9+Py0jxGY+YTpnrQGSe12kG3aGBNN6EGOvZELSjoDpk4MouEOzgEUi4CNth0shOGQKYBv1m5MItGM0kNPGKZhdtMt1fcdKMsX089Sb3CkpfAmiTOTifRUiXC/ePWvfj1/TvQmkni7688ARtWz/G8ngQr64BZA17BxaYSs9PJupBrpBir+aRL1i7EP1oiLuS5QecAUQkKukMmrbG6utETJeSjbjckGENa0zDBOWZW7WFZnxjWtiYtbWyUXSmrarphRp1+gm433SglSWaup56uxTAzo4yxqo4ih/qz+Pl9r2Ld8h589PI16PTZQMdrIayXp0uwFTHHTUpj4LoodnV1wpzXxp+VJ+Kj5F5C5wDhTH18o01jUgkzs8jr6GZPWL7VHh51A0BLgiHHG/NYcqvgUDrqGIhuG2RA5hSMMMaKrem9UvTodvHeIOsJi7DcS9zwp7/sR0Jj+MhbV/sOuCFlO1YhrBs4GrNnQYqViikrwemG2vTQ8SdqQedIyKS0+nusTVRv2FKJFk2DEAK5BiyMNWwaWUQcfNYKRhI+M91yG9xkumEFiPV0HQrLJz5qcgUDDz93EKce14uZMzKBluVVHuTl6VI9UQy6q2yny7pVYhpDhZRELRrx+6+hSFla4HprzNHsyIDNS6Y7o5nZWi8a1nrBdGopTQKjtA2s1ZE18f+3d+9RctRl3sC/v19VX+aamcn9AolBAhEWk000rhouYY/XLOKyKi+HHF9eOeLiIroisMsKCMjZ6O5BF/Cwrr6+Z89Z4ayKLCCCroAXFkK4aRDFGDEkmckkk8lkrn2p+v3eP6qqp6ene7qqu6u7uuf7OYczZC7d1dXV3U899fyeR1T2+vAzjXLG/USs1Eu7We56lyM8+5tBTKQsnLdxZdW3FWQhbCVXl6LCEM7zNFemWwc8iafWw5aBVA6D7pB5/WWjNoJ6vptrYEspUggkpEAqSjUKPtna2X5DiIprqCtVLtAyq850+/t90x05ryMSeGvdmA/nJ188hBWLOrDupJ6qb8sMkOmu5OpSVAjhdFEpl+luxhMKqh1DAL0xE+0NnKBK0cYjI2RSOMFOlDJsVPnI5qSUyGhd9wEz1fAyjF62rt61zeVKCgwhch1VgvCmUfo9cTKEyO2LKNANyIi9NjCK1wbGcN7GlTXJsEv4X6BaydWlKInJcpluZjjnOyEEumOG76tvNP8w6A6ZECJytaQ03Ts6aACQNJyFYyk7KqFbeQpuhtH9IKi0hrry+y9fXoIKSrD8TqP0RG1CrG5A7ecTLx5CImbg7Wcuq8ntCXdwja/ykgquLkVJzH3dlFpI3ayLRImofhh014FTsxqND3pyTPeODvYhGXczq6kmKhfKlWG4/660hrpSfjLdqKDO3O80So9ZYXAfFq11XVuLTaSy2PXKIP7sjKVoS9SuW6zfkzi7wqtLUZEbB18q6Gamm4jKaNb3v6biZLqjU0tKlZeXCK+uu4kWU05n9acz3fVqe+iVc8wVG08vxgsYdMNfj+7p+3GD+ypPmCyl0T+Wqnof1ru85KlfDSBrKZxbgwWU+QyfVw/mGpLUDMq1DdRN/NiIqD4YdNeBKaNVS0rOpWARoB44X5shYSk9Z31nlHg9lL3g1stM1uMk0M/iuVwwHOR2A0yj9Ej3pKnaq05jto2RdBaZKp//epaXKK3xxIuH8MaVC3Dy0q6a3rY3Cr7c8VR48tdsvAFLxTLd2n09NeMiUSKqHwbddRC1WlKqrl9w0u1I0yzZ7tmZbuf79VhM6Se76QXDQTLdQaZReqbrjyt/4FprTLr1/NW+nuvZs/o3+49j8PhUTdoEFjLdBarl9kalV5eiwulgUjzTrXK/U/fNIqIm0qzvf00lV0vaJJnR+cDpHV3Z35rCye41y2LK2TXd9ZtKmQv45/gdIYQzTjzA5gSZRpnPK/WqVFbr3Ou42qC7nu8GT7xwCJ1tMWw+fXHNb9vvQljv6lIzx6Wl2gbqJj+hIKL64HtEHUxnuhu9JeRRVVzmFkKgzZBIqfqUaFTLG07jtYgz65npzrWJm3tfB+2oEnQaZaX3U2jSdqZIGlUG73C7edRjMM7waAov7R3C1rOWI2YGPU0pz+9CWC+zX+9hQLUUk8XX53h9/5v3kRFRPTDorgOvlzDLS6Kj2kv7SeksRsw0wXNqF5R3VNotpBLePZS7qmAEfH0EnUbpMcu0fStnylZISIGkKavPdNepvORnv+yH1hrnhFBagiBBdwssNIwJp2VotuChap8nl0Q0vzHorhP26o6WanvqJt2JY80wnVIV1D57A03qEXRPl5fMva9NBJsWGXQaZe5+qsjyZ5VGRim0S4mYu5i2GvXoXmLZCj/9ZT/OXLsQS3raQrkPv/tUtcBCQ7NE28Dc2oUGbBMRNQ++R9SJKRl0R0m1mW5DCMSkbIrFlHbBY63nVEq/beIMn4vxPEGnUebfDyqsx55ya/jbDIm4lFVlzFGn7iUv7R3CifEMzvvTcLLccI8nP1fylG6RTHeR9TlcSElEfjDorhNvalsz1AC3Ou0GS9VeCm6TAmlVXeBVD4WZbtRxKqXfjhVBO6oEnUbpMasorZlUCnEpEZMCMaO6jkTeCUbYMdrjLxzEwu4kzlq7MNT78XM8tcLERikETDl7MaX2eUWHiOY3Bt114rXVCtKLmMLhZaUqCdryJQ0JrTXSEe5K4/WHL8wwBu0WUqlcxwofCykRIIgNOo1y+n6cdGTQYNlyn+c2t6wo7raNrGoxZcgTKfuHJvDb10dw7sYVkCGnmP2Mgq9ni8QwxYSY1TaQmW4i8qMV3gObglnisiTVX636BSekE0xGucREe/2s0bhMt5/9HHRxZ9BplB6vtCZosDxlK0BrtLtnajHDC7orzHR721PRX/vz5IuHYEiBrWetCPFeHOWOp1Inf83IdNsG5l+1ZMtAIvLDbPQGzBcckBMdXnuvai91SyEQl8JZTBmr0cbVmJd9LJ7pdgKHMFu4+Q20gpSXVDKNMp/znKlAJUaTtoIpRa6m1xDO81/pSXQu6K7xrk9lLPQPTeLQ0XE89fJhbD59Cbo74rW9kyLKHU9+JpM2i5gU0JZzDHqLSP1e0SGi+Y1Bd53kBuQw5m44VSIQrURSSpywbLfGOHofuKpEa73pzPL0sRnW/fsJtLxFkX4y3ZVMo8zXbRoYTGcxbil0x8r3rba1RkppdJsyF1Q50y0rXxztHYOV7nrLVjh8bBIHh8Zx6OgEDh2dwMGj4xg6kcr9TkfSxHveenKF9xCMWeZ4quVrrtG8E6+s1jDdZ1Br9ugmovIYdNeJyA3UYNTdaH7b2PnRJgVOaI2UrdARwuCRanlrCGZnuqenUpohhgs6QMcKw+eI9kqnUXqShkSb4ZwsdZqybLZ7urRkZvGAKWa3jvPLb3mJUhpHR6Zw8OgEDnkB9tAEBocnYbuRrCEFlvW1Y+2Kbmw9azlWLu7EysUdWLygLfRabk9+TX6x46lWV5eiIOa1DVQabe5B2CqlM0QULgbddWTK+tTR0tz8trHzIy6dDG1KaXRUf3M1l8t0FwRC9ZpKqaBhCH+Vrk5dcPnfq3QaZb6emIGBVBYnLBu9sbnfBidtBUMIxAvuz5QCU1alJTruBMMSf/fkS4fw0xf70X9sAllres3A4p4kVi3uxJ+uW4QVizqwanEnlvW1wzQaW008XR5U/Ams1TqKKDDcqzL5J1wq5EWxRNQaGHTXkSkE0hFedDdf2DUMAIQQSMjoLqYsXdNdn6mUQTpWGEIgrcvvx0qnUeaLS4kO08CYpdBl6lx5RCHllpZ0GnJWgJzfkSjoG2mp8hKtNR7+nz/i+z9/DWuWdeG8jSuxcrETXK9Y2IFEPHpXU1BQrlRMqSsuzSpW0DZQt9BjI6LwMOiuI1MAE26vbi64aRxvAV2tnoOkITGVsZBVOnfpOSqUe6wVXtav11TKIJfdDeGseSj3+qh0GmWhBaaBCVthNGujL178rXBKOZnswtISFHQkMgNuTLHyEq01vvfTP+CRZ/bjz85Yhv/z/tNhyObIDUv3BLTU8dRqfaxjQmDSnj5BVFUs7CWi+aM53tFbhCkEoDUXUzZYresv29zAKIrZbrtEcFqPqZTa7WbhN9DyXh/l9mKl0ygLxaRAlyExZqtZfZc9U7aCdK9mFN3eCjsSFXYvUVrj2z/ei0ee2Y9zN67Ex7avb5qAG7k1K4BV4uelrrg0q5gQUFrnTjI0mEghovKa5129BbBtYDT47ajhlymcy+spO7ygW2uN4xkLmYCB/VyPNexe3UFr5/2WvFQ6jbKY7phT7X7Cmj22SmuNKVuhvUhpCby6+AoXR3uZX+Eulvx/j/wWP3nhIN791pOw413rmnLBoTnH8aSgAdE6Vc/5iynRQoN/iChcfJ+oo3rV0dLcap3pFkIgachQJ1NaGhi1bEwEDOzn6mcd9lTKoIvnvO0sdyWo0mmUxZhCoMuUmLDsWSc0KaWh9PQUykJO28DK2oB6f2LbGl9/6Nf4xZ4BXPCONfjweW9s2ozpXCdxSjvdZpr1sRXKbxsI9z2lNR4ZEYWJQXcdVZMZo9pxsr+1FXc704T13Hof7kEDPIXSA2DCz3QHaxPndVgpm+mucBplKQtMA1IIjGRnZrsn3dKStjnO0Crt1a0B2Erjmw+/gmd/cwQfPu+NuHDr2qYOSr2TOF1kf6gWG5FuCOcEIuvW/GutW6Z0hojCw6C7jqrJjFHtKF37fsFezW8mpGy3N/kwyATEcpMb86cIhqGiTLePceLVTKMsRgqBBaaBKVvlSoS80pJkidISj1nhVMpMVmHXbwbxy98PYce71uE9W+ozxCZMhtvNpdi1GKX1rLaVzUwIZzppVuu8RbGt8/iIKBzsXlJn1Uyxo9oIY5BF3O2GklaqaKeLak1nugME3W7wOFdNN0KcSun1CPd7fuNncWe10yhL6TQlRi0n271UCqSVs0iuvcyB4tUx+xkpf3wsjd8fOoG9B0ZwcHQKbd1JfPQ9p+Odf7K8po+lUfLL5wqfn1bs7hGTzuu9ln3/iai1MeiuM1MIZ8IdNYQK2FHDLy/zFVamO1c76jPAg4/WemFPpZwORvzf9tx1wTr32ql1t2opBHpiBo5lLEwpZ8KoEKJkPbfHO1mxtJ4xPEdrjYFjk9h7cAR7D57A3oMjODrijGiPxyQ2nrkMG9YvxVtXLqjxI2mc6X0BxAt+pqAR8zkkqVnEhMCEmu5g0lqPjojCwKC7zowAmTGqvTCzUgkpMG6rmvdh11ojq3Tu2CkM8EopV1Md9lTKSqYQFi7utN1Ae8pWuZ7ZUgjEQ2in12FIjEqBkawFDSApi7clPDGRwbO/ew2Hj4whpRTiC5L4Uf8Yjh+fxGTawmTKwvhUFqmMUyPe3R7Dqat6cP6frsKpJ/XgpCWdGFMKY5Zq6hruQnMtFG/F7h6xgpKyVnouiSgcDLrrLJYX6PByZP2pELNScSmgLY2sz6DYL+Vud4dpYMKykS2SSSymXKZbhtxNp5I2cYZbojNq2U6NtdKAW67QaUi0GRJJWbvBRvmEEFgQMzGUzgIAFhRMfxyfyuLRXa/jv58/gEzWOX3raI/hrA3LMTqVga00ejsTWLmoA+3JGE5e2ol1q3qwpLdt1vZqW7VcBbCB4jX5Xp13q73feS1gvaC71U4qiKj2GHTXmZcNsrRGrOU+dmdLK4WjaQvLkrGSo7brKZd9DWFbEm72NaM04jX8BPZ6AbcZTms7y+u/VoYqMwWwVJBUK1pPTyr0y3SHjhzPWIhJgW5Tot2QuZr5sLVLJ4ueyWsVOJW28OPdB/DY7teRStvY8qal2PH+NyEunKz7gVQWnYYsOdWyGN2CLeZK1eRrOAdDq0yj9MTchb9pFWztAhHNXwy668yU82tAzqStYGuNTAWjssMQZnmJKZxgPq00Omt4u149d8Itd/B77JTLdIc9lbKS7GanKSGFiaSUucv39SSEwKK4iazWsLIKP3rhIB55Zj8mUhY2rVuMD2x9A1Yt7sTixV04enQMqHBxtG7RIM0osi+mT3Qbs01hcdZxTL8+W+2kgohqj0F3nXkDIuZL0O1lgaLyeMtlf6shhEBc1n4xZVY5GVUjYICn3NHUcz3SMHt1VzL50xACXWatl0kGo22Fp37Zjx88vR+jExmcdcpCXLj1DVizrLvo7+cHXr7vQ+uWbDFnFGmJGrRfezMxhUDWHarUaicVRFR7DLrrTAjhfDCFOL0wKpSb4UbA/tJhUmWyv9VKSIETlqrpQtms1jDd8gpTCt+j4G0f5R1hTqVspjperTX+MDCKp/Ycxq5XBjGVtnD6yT345AfPxKmreub8W1MKTFk60ALaViwvgRuEpguOz0oW1DaLmBSYcmcqteLzSUS1xaC7AWJCzIsBORm320SUpnBWsrgviLiUgLaRURrJGkX2WaWRdOuLTQFMulP/ygV4ykc/a0P4D+KDUnp64XBUHR9L4+lfH8ZTewYwcGwScVNi02lLcPabl+O0k3t93YbpDoWxA7yhtnJ5SWFbS2/OZ7OcgAXhjYMP8z2FiFoHg+4GMIpkg1rBUyeSAAAgAElEQVRRSilACCRlhILuChb3BZE/mTJZgyoJpZ0+wN6HuykE4E5lLDfQxk+HnPyplLXeJ0pryBBa+1VrKm1hzx+O4Rd7BvDr14ahNXDqqgX43+89HW85fQnaEsHeFr0FwlaAdQvuuWjL8R5+/rGnW7jm2Vt3EOZ7ChG1DgbdDWAWyQa1orRyWufFpcBYwMvvYQm75MFwS0DSNTrJ8GqFvQ93M6/7TbmBNn4Gkhh52chavxmoBpUU7Dt0AoeGJnBiPI0TE5ncf6Pjztd01sm99nUn8P4/W4N3/MkyLO1tr/j+8p8Tv1SLvvmaeW0ove5MdosupEReprsFHxoRhaAV3/cjr9QUu1aitXa6eBiyosvvYalkcV9QcSlrVrLhtQv0PtxjAQI828dAkvyBJrVs6ahDyp7PJZ2xce9P9uJnv+zPfa8jaaK7I44FHXGsXdHt/H9nHKuXduH01b01Oek13dZxQYJuDQ3RYhMaUdAS1RN2SVcjSfckuxUfGxHVXqNjoHlpum2gvyEnzSjt1nMnjekQN8jl97CoOgwlSgiBSXc8dLma6nKybuDqnagZboBXrluGF/SWr+l2vtZ6MWWYrRmLeX1wDP/64K9x+Ngk3vu2k3HexpVY0JFAzAw/sPWeH7/rNLTWLTmhESWOJ6+tfKOvcoUlLgSiUTxHRFHHoLsBKrkc3Wy8VoEJKXLdC6LweG1oxEPOMMbdSDOtNNqrPMnIKg1TTAcsfgM8v5f05xrdXY16daxQWuO/dx/Ad3+6Dx1tMXz24g1405q+kO91tiCtHDNuaVmyBestpHB6ydszMt2tWb/uWRhgKBIRzW98t2gAb9FNVNrohSGlFGJSwhACEtHpYOJzmGNV4lIAbleQdqO6sLPYSHnTx7Hj9UYum+lGOFMpdR16M58YT+ObP/gNXn5tGBveuAiXve90dLU35tqRKQSmbH8lRVO2u8C4ymMjqpxe3XlBt9YwWrgAo5XX5RBRbTHobgAnWxmNIDQM+fXcqODye5jbVY+smxQC8bzx0JXSWsPSQIcxO+ieLFMzbvvMNIc1lTLsTPev9g3h//7gN5jK2NjxrnU4d+PKhpYvmO6Ji5/F0VO2RkKKqkuPosoZuDT9b6XD64tPRNRMGHQ3SBSC0LB4/bkTeZm8KJxkaDi92uqRdYtLgUlbVbWYMKs1kNcu0OOn+403edNPYBfGVMqwarqHR1N4dNfr+O/nD2LV4g587n+dgZWLO2t7JxWYXhwNxOd4zLbWyCiFnljrvvWaQmAq76TQTxcdIqL5oHXf+SPOm9wWhTZ6tZZy05z5NatBLr+HRfmsc66FhBQYt5xMdaUDYrLu9sYKNnh6IW7p7jdB2rSFMZVS1bA389CJKTz/6lE89+oR7Ds0CgA4f9MqfPi8UxBr8Mh4z4znZI7H7L0G2lo49WsIpwWl997WqotGiYiCYtDdILlsJcKvMa63tFKIFVw+D3L5PSyqDnXGnunFlAoxWdkznFVOLXxhK79Yfla1xN/abh29n2AnjKmU1Z7gHBmZwvO/PYLnXj2C1wbGAAAnL+3EX569FptPX4JlfZX31Q6D38XRU8rpKFN49aKVGN4AJwCG+x7XgmtGiYgCY9DdIPmZsVaq7dRaI6U0OgoWifm9/B6menXUgNtPWwqBTBV13ZZ2OpcUniTkT0AsdcYWpE1bGFMpg/RmtmyF/qEJHDgyjtcHx/G7AyPYP+gE2m9Y3oUPnXsKNp22GEuqGGATNj+Lo7XWSNnO4tpWu7qVL78jjnQD8FacRklEFBSD7gbJBaFKI9FC114zbvBW2A7N7+X3MNnu13pk3YQ7ibOaxZRZNbueG3lt2ebKqtoBriiEMZXSKykoDC6zlo0/9I/i9SPjODA4jtcHx3BoaAK2u5/ipsTqZV34yLY3YtO6xVjU01ajLQqXn8XRaeVc6Wlr0a4lHu+9zc47J2Smm4goAkH38ePHce211+L1119HPB7H6tWrccstt6Cvrw+nnXYa1q1bBymdD6kvfelLOO200xq9yTUxfTm60VtSW2m3ODgxK9Pd+N7kuTrjOmUZ41Jg1Kqsbl9rjazWSMriAVq5AE/Bf8eIMKZSFispODIyha9+55cYODYJAOhuj+HkpV04Y20fTl7ShZOXdmJpbztkk0Zoppj7+J5SCkKIluzPnS9/KqUXgLOtHhFRBIJuIQQuv/xybNmyBQCwc+dO/NM//RNuv/12AMB9992Hjo6OBm9l7fnJVjajlFIw5ew65Cj0Jq9neQkAJKQEtI2M0kgEXDhnaSfwLlxE6THl3HXYttaIlwjYC4UxlVJpjfzikt8fOoE7v/crKKXxiQ+cgXUn9aCnM1G7O4yAmBBIqdJlOl6rwFYPQL3XurOGQ+S+R0Q03zX8vbCnpycXcAPAhg0b0N/f39BtqpeYLD/Ou5l4/bmLZWej0JtcwQmG6hXy5BZTVvCYvf1UKvNsuh1HdInbDjIEKIyplDov0737t0fwpW+/iLa4ib/fsQlvXb+05QJuuCdC2l1AWMhSGlml0ObzRKiZCSFyHXHqWdJFRBR1Dc9051NK4d5778W2bdty39uxYwds28bZZ5+Nq666CvF4YybOhSEmqu/lHCXZMuOtG92bvFSdcVhMIdzOIMEfdNb9m5KZbuEGeHq6htajc11i/N1XGFMpvYEojzyzH999ch/euGoBrvrLP2nYxMh6yF/gahZc2fD6Vrd6PbfH6/2ua9g6koio2QldKlXWAF/4whcwODiIu+66C1JKDAwMYPny5RgfH8fnPvc5rFu3Dp/5zGcavZk1MzyVweGJNE7t7UCsBT6Myz2ewYk0jqcyOK2vsyEnGQdHp5C2FU7prV+50sHRKaRshTcGvM/+8RTGMxbW9RUf/DKRsbB/dAqru9vQEZ957pxVCnuHJ7CsI4G+Nn9B7t7hcXTETazoTAbazlJePTaGn+0+iAd//DucvWElrr54I+KxVmuOOVPaUtg3MoEVnUn0JGMzfnbAO/Z62lviBLucg2NTSFkKvYkYBifTOH1hZ8uX1RARlROZTPfOnTuxf/9+3HPPPbmFk8uXLwcAdHZ24kMf+hC+9a1vVXz7x46NQzWgnnjx4i4cPTpW9GcpW2EyncWApVoiA3Y0nUVGa4yU2M0Tlo3xjIXDdvAFe3PtR79G0lloAEet+g3pSWVtjGQtHM7agVpDHktnAQBH7eKPOas0JlMZHMna6CwYEJNRCpOpLEazNuzx9IyfldqPU6ksMpMZxKayvrexlMmUhUdfOojf7DuG7W9fjQu3rsWJkcmqbzdKiu1HrTUmU1kczVjI5k2cVFrjSCqLTkNiqI7HXiNNZiyM2QpqKoNJS2FIjZU82ajFa5u4H2uF+7E25vN+lFJg4cLiCbNIBN133HEHXn75ZXz961/PlY+cOHECiUQCyWQSlmXhsccew/r16xu9qTXllQ5klEZbkycBvf7cc508zHX5vR68kod6Ssx4jv3dudYaWaXRPue+dEpC8tcEvDYwildfH4EwJczuBH47moYuCPJ6e9oQE0BvVwJ9XQl0dcQh82pwC7djfCqLoRMpHDuRwtCJFIbHUoiZEu0JE+3JmPvVzH21bY1/ffDXWLK6B+/avApbT1sabIc1MSEEjCIdidLu4spWOLH2y3DLn6wA/eKJiFpdw4PuvXv34p577sGaNWtw8cUXAwBWrVqFyy+/HDfeeKPT8cKysHHjRlx99dWN3tyaMoSA2SKLKcvVcyMCbQMVNGKivoFPXApACKSV/6sZys2OlqrnRm5h6swA7yfPH8T/vHwYPb1tWLO2D7/99SBSKWvO+zKkQE9nAqe8sQ8L+9oxNTSJ4bF0LshOZ2cuC0zEDdi2gjVHq5OOthg+cOYyrFtU/Ey/lZly9mLhKdtpFZiYR6sJvfPLrNJgvE1E5Gh40H3qqafi1VdfLfqzhx56qO7bU2+xKqcWRoU3BCYxR3cGLzvbsKBb179dj3RHfgd5jnOLKMtEK2ZBC8b/8/71uPRd6zBuK5ywbHzs7LWzSlo6u9uw74/DGB5L4fhYGsfH0hgeTcNWGqNTWfzyd0fR25nAkt42vGlNHxYtSGLRgiQWul/bkzEnE28pTKYtTKasvK9ZpNI2Tlvdg0zSnJcdK2JCYMqevrqgtcaUUkjOg1aB+bzjLqs1EvPocRMRzaXhQfd8F5MCUxUOUImSlNJuf+7Sv1MsO1svQTt61FJCButS41358BN0T+b16pZCIBk3kcpaMAG0x81Z99fblcTqZV1YvaxrxvfHLBvDGQsffefasvX2QgjEYwbiMaNo67+MUhhIZZv6eK6UmetPrd0+/E45VXe8yevHAsodQ1o37bAjIqJamz9FhhEVFwJwpw82K6010rZCQsqygVajenV7oWkjso1xKaDc+lY/nEvyomz9uSmc21UF+9OuoDViLXt113sIUZR4J53ec+1lvedDf+58+cfufMrwExHNZX59EkSQV7ebbeISE0s7wZqf8daFJRH10shAcHoxpb/OFVmtEROi/AmMLF4jr7QOvGC0llMpp09wqr+tZlP4nEwphZiUue/PF8LtUQ9+yBAR5fD9sMG84CrTxJnulBtMzlXP7cm//F5PCu6QjgZk3bznOO3zZCOr5l5EOX27ztfCDLqq4HHWNtM9fwei5C8WVu6EVr9da1pNLuienw+fiGgWBt0N5o1Hb1SmW+dNjatUWmmnE4uPD9fCy+/14u3eRlTWCiEQl/4WUyqtYbuZ7nLyWzDms7UO/DhrOZVyPme6vbIeSzktNLXW8660xOOda8zHky8iomLm56dBxPgNyGpNa41DqSxGqxjYobVGylZIGOXruTFHSUTYvOxroxb3JaRzNaNcaU1uEaWPiFUK4S7WKywvCZ7p9npM16K8RM/jmm7vJNrSGlO2gpxnrQLzMdNNRDTTfPxcjJyYm2GsRZYxiLRy7nPMsivOdgep50YDe3V7pxWNutLfaTi55+GsNee+9tsu0FO4MFVrDbvCx2nULNPtLASdj91L4F7N8YLupJy/+2E66J6fj5+IqBCD7giIN2gxpVeLbWuNqQrvOx2gnhsFl9/rqdEdNWJSoMc0MGUrTNqlryxktQZ8lurAvXKQ3/lGwW3TVkGgU2wqZSUa0Q89SmJuuZg9z6ZQFjJz5SVERAS+H0ZDroNJnbO/KaURdzsrjFm2j7+YbcJWMKXILeorJ//yez0p3fjsa5cpEZcSx7N2yYxyVmnEhP8yGNMNlL3suV1F7XrNMt0N6oceFfmdSuZz0J2QEjEpfZVKERHNB/P3EyFCDPcSbD3ruvM7K3QYEilbBc60p5VCylboMoxAwWwjBuSoCBzsQggsjBuwAYxki5/kWD4XUXpMIZySEnd/5jqHVJrpBqpeWFtJ95RW4pVQxaWcNRF0PolJgRXJ2LzeB0RE+Rodh5AbjMUKygTCllIa0BpJKZ16YyEwbgfLdo9azkKxTjPYYRRzM93VBndB2BWWXNRaXEp0mxLjlj1jXDjcYDer/S2i9BTWyHvPYKU13dBO141qzPfyEu85ma+tAomIqLj5/NkYKXG3DrRegWjKVhBuZwVTCrRJgQl3HL0fWaUxaSt0mjJwMGtKJztbec+U4FQDF1EWWmAaMKXAcNaa0a88q5167KCZbuQF3dVkutsNpxTgaMaadUIQhEI0TnAaxRTAwriJLnN+jX4nIqK5MeiOiFjAUeHVSqmZnRU6TSPQgsoxy4YAKgosSvWXDpPSiEy3YCkEFsZMWErjRF4tfZB2gR5TOP21rRrVdC9NxBATAkcyFiYqrPOf75luIQQ6TYNlFURENMN8/myMlHgdF1NaWiOrnNIST5t0xjaP+wi0bK0xbiu0GzIXQAfRiLaBzmj06ARBSUOi0zQwaqnceHjvJCTIPhVupxMrr6ZbVrFg1Am8TSSkwFDW9nU85NNaQzvnAURERJSHQXdEeCUF9WgbmHJLB5J59RbCrc2eUrrsNoy7ZSjdAWu5PV52NlvHxZQqgkM6emIGDADHMrZbz61hShG8XCevBaNdg8cphcCSuIk2KXAsY2G0xKLPYrQbeHMKIRER0UwMuiNCCqe2OlOH7G/KHdteWDvsDXCZmGNBpXaH6bQZTvu7SnjTD+uV6fZG3UctEDSEQG/MQEYpjFnKbRdY2ZWD/JruWmT0pRBYHDfRbho4nrUwUmaoj2c+j4AnIiKaC4PuCHGGaoS7vNAb254sMrbdW1A5PseCynFbwdYa3VUuEjNl/Xp1RzkQbDck2gyJEct2Mt0VBt221lBu68BavaiFEFgUM9BpGjiRtXE8W35yaaOHEBEREUUVPxsjJC6dkgu/HUS0Ll8KUijrjpsvNbZ9rgWVXpY7LiUSVUawZh2nUtoRDgSFEOiLmxDu/q1kkIg3+c9yA+9a1q4LIdAXM9BtGhizbBwrE3jrKrqnEBERtbIoxiHzVsztk+x3MeWopdCfzgYKvL0ezMkSpSFzLaj06r27zdlZ8qDys7Nhq6aNXj2YQqAn5lw5iFcSdEtvYWo4tevC3b4FMRMTlpPxLiXKVxWIiIgaiUF3hHg10n4mU3pZZ2iN0QAdJlLu2HazRFSUv6CyMBM9atkwpUB7DUZbx3LZ2apvqqxmCAQ7DYkVyTgSFdTJeyUpGeWUBRkh1K57gbeX8S7V1SR3ghOx+nkiIqJGMxu9ATTNFE5w4ydzPaWcMhFTCkzYCj0+ygq0O22ws0zQ3GkYOGEpjNs2eqRziKRthbSt0Bs3q85yo6BtYLzKAG3KVnO2trNy5SXRDQSFELkTkaAM4XQ8SSsvo1/bbcvXEzOQ0RrDWRsxKWadJDTDCQ4REVEjMNMdIcLtKOKng8m4ZcNwO0xod1hNOWl34mWyTNBdbEHlqGU7I99rkOXGjJKI6lLdltYYylhIK2eEerH/tNsX22zhQNAUIneFJMx+5EIILIqbMAQwlLFgFzx/XEhJRERUHDPdEROTItdHuxTLXejYbTpt+9qkwJil0G3OPX47pRQgRMlFlPk6TQNH01lMKY2YACaVxoIKRr6XIt0ArtrFlMczFjSAZYlYRYsQW4UppsuSwt4N3sne4bSFoYyFJXlXPxQ0RBXDeYiIiFoVE1IRE3cXGBZmEPONWwrQOtdXu9s0oLTGRJlgPaU0EsLf8JX8BZWjVYx8L8WZpFhd28BJW2HSVlhgGvM64EbelQMAodR0F4pLiYUxAylbzVhYOd9HwBMREZXCz8eI8YLHUnXdWmtM2DaShsz9btKQSBgSo1bpdm5Ka6SVnjGFci75CyonbIUOQ9a8bCF/fHlQSmsMZyzEpax4MmYrye/vXa/zjw7TQFfBwkrFEfBERERFMVqJGK9lXKm6bq+rSGdB1rnbNGApjckS2e6U0oDWJVsFFuNl0nUNhuEUE3Mz3X77kuc7nrVhA+iLGyxlyAu6hc8rGbXSGzOQNCSGszbSbveUKC9YJSIiahQG3RFjCKeso1Sm21tA2V6Qzmxz2wCOlpgmmbIVhBCBhtqY0lk42RlS+YYpBbTWCDqDM+V2K+k2ZUUt9lqRF3T7vJBRM4ULKy2t2bmEiIioCEYsERSTomivbm8BZUeR4TRCCHSbBjJK5VrH5UsphaQMvsBtYdzEwng4621zbQMDLKbUWuNY1oIpBRaEkH1vVqZw6joakWX2Flba2imLiuoQIiIiokZi0B1BcSGQLVJ2UbiAspBXd104LMdyx8UHKS2ph/xe3X6dsGxYSqMvZjK4y+MsTK1/ptsTlxJ97lTNaB1lRERE0cCWgREUkwLa0rD09OTGYgsoC0kh0GkaOJG1kFE6Vx/utSD0u4iyXry+2VmfMXdGKZywFDpMA2016hfeSpwTkcbdf6fp9E2Z751kiIiIimHkEkGxIospUyUWUBbqcktP8oflpJQzrTIWscywcOvX/WS6tdY4lrFhuIv3aLY2o/E17h2mgXjErqgQERFFAT8dIygmBCAEsmp6ieFYiQWUhQx3auSErXKdQVK2QsKYXQceBab0F3QfT2WRUQq9MSPUiYtEREREYWDQHUFSCMTEdK/uuRZQFtNlGrnR8Fl30E5bRC/5mz6mUlpK48hkBm2GRDvLSoiIiKgJsaY7omJC5MpLyi2gnPW3UqDdkBi3VK6bRdQWUXpMdwKn1nrWCYWlNaZshTFLIWHG0RczI5mtJyIiIiqHQXdExaTEpGW7493nXkBZTLfp/P0Jy4bp9vCOIm+hqLdoNOsO+Jm0FTJueY0pBVZ0JpAeTTV2Y4mIiIgqxKA7ouJSAFpj1G2R15MI9lQlpETSkEjZCm0+M+SN4LUNPJ61cq0N4bag64mZaDMkYgLoTsRwFAy6iYiIqDkx6I4or9PIqKV8LaAspts0kLIVkhGugzals2h0SmkkpUBX3GkHaLKMhIiIiFoIg+6IMoXTUk9rjY6YUVEtc5shsTwZz5VwRJEhBFYkYpAC7EpCRERELSu6KdB5TgiBuBuE+l1AWUy8gtHv9RaTggE3ERERtTRmuiOsw5RIKMEJf0RERERNjkF3hHWVmT5JRERERM2B5SVERERERCFj0E1EREREFDIG3UREREREIWPQTUREREQUMgbdREREREQhY9BNRERERBQyBt1ERERERCFj0E1EREREFDIG3UREREREIWPQTUREREQUMgbdREREREQhY9BNRERERBQyBt1ERERERCFj0E1EREREFDIG3UREREREIYt80P3aa6/hIx/5CN797nfjIx/5CP74xz82epOIiIiIiAKJfNB900034ZJLLsFjjz2GSy65BDfeeGOjN4mIiIiIKJBIB93Hjh3DK6+8gu3btwMAtm/fjldeeQXDw8ON3jQiIiIiIt8iHXQPDAxg6dKlMAwDAGAYBpYsWYKBgYFGbxoRERERkW9mozegXhYu7GzYfS9e3NWw+24l3I+1wf1YG9yPtcN9WRvcj7XB/Vgb3I+zRTroXr58OQYHB2HbNgzDgG3bOHLkCJYvXx74to4dG4dSOpTtnMvixV04enSs7vfbargfa4P7sTa4H2uH+7I2uB9rg/uxNubzfpRSlEz0Rrq8ZOHChVi/fj0efvhhAMDDDz+M9evXo6+vr9GbRkRERETkW6Qz3QBw88034/rrr8fXvvY1dHd3Y+fOnRXdjpSi5tvWDPfdSrgfa4P7sTa4H2uH+7I2uB9rg/uxNubrfpzrcQutdf1rLoiIiIiI5pFIl5cQEREREbUCBt1ERERERCFj0E1EREREFDIG3UREREREIWPQTUREREQUMgbdREREREQhY9BNRERERBQyBt1ERERERCFj0E1EREREFDIG3UREREREIWPQTUREREQUMrPRG9CqXnvtNVx//fUYGRlBT08Pdu7ciTVr1jR6syJv586deOyxx3Do0CE89NBDWLduHcD9Gdjx48dx7bXX4vXXX0c8Hsfq1atxyy23oK+vDy+99BJuvPFGpNNprFy5El/+8pexcOHCRm9yZF155ZU4ePAgpJRob2/H5z//eaxfv57HZIXuuusu3HnnnbnXN4/H4LZt24Z4PI5EIgEAuOaaa7B161buy4DS6TRuv/12PP3000gkEtiwYQNuvfVWvrYDOHjwID75yU/m/j02Nobx8XE8++yz3I/FaArFjh079AMPPKC11vqBBx7QO3bsaPQmNYXdu3fr/v5+fd555+lXX301933uz2COHz+un3nmmdy///Ef/1H/3d/9nVZK6T//8z/Xu3fv1lprfffdd+vrr7++gVsafaOjo7n///GPf6wvvPBCrXlMVuTll1/WH/vYx/S5556rX331VR6PFSp8f9Rac19W4NZbb9Vf/OIXtVJKa6310aNHteZruyq33Xab/sIXvqA192NRLC8JwbFjx/DKK69g+/btAIDt27fjlVdewfDwcKM3LfI2b96M5cuXz/ge92dwPT092LJlS+7fGzZsQH9/P/bs2YNEIoHNmzcDAC6++GI8+uijDdzS6Ovq6sr9//j4OIQQPCYrkMlkcMstt+Cmm26CEAIAeDzWEPdlMBMTE3jggQdw9dVX547HRYsW8bVdhUwmg4ceeggXXXQR92MJLC8JwcDAAJYuXQrDMAAAhmFgyZIlGBgYQF9fX6M3r+lwf1ZHKYV7770X27Ztw8DAAFasWJH7WV9fH5RSuct/VNwNN9yAp556ClprfOMb3+AxWYGvfvWruOCCC3DSSSflvsfjsXLXXHMNtNbYtGkT/vZv/5b7MqADBw6gp6cHd911F3bt2oWOjg5cffXVSCaTfG1X6PHHH8fSpUtxxhln4OWXX+Z+LIKZbqIWd+utt6K9vR2XXnppozelaX3xi1/Ek08+ic985jP40pe+1OjNaTovvvgi9uzZg0suuaTRm9IS/uM//gMPPvggvve970FrjVtuuaXRm9R0LMvCgQMH8KY3vQn3338/rrnmGlx11VWYnJxs9KY1re9973u46KKLGr0ZkcagOwTLly/H4OAgbNsGANi2jSNHjswqmyB/uD8rt3PnTuzfvx9f+cpXIKXE8uXL0d/fn/v58PAwhBDMhPl04YUXYteuXVi2bBmPyQB2796NP/zhDzj//POxbds2HD58GB/72Mewf/9+Ho8V8I6zeDyOSy65BC+88AJf2wGtWLECpmnmyh/e/OY3o7e3F8lkkq/tCgwODmL37t34i7/4C4Cf2yUx6A7BwoULsX79ejz88MMAgIcffhjr16+f15dUqsH9WZk77rgDL7/8Mu6++27E43EAwJlnnolUKoXnnnsOAHDffffhve99b4O3NLomJiYwMDCQ+/fjjz+OBQsW8JgM6OMf/zh+8Ytf4PHHH8fjjz+OZcuW4Zvf/CYuv/xyHo8BTU5OYmxsDHAaIeCRRx7B+vXr+doOqK+vD1u2bMFTTz0FuB2yjh07hjVr1vC1XYHvf//7OOecc9Db2wvwc7skobXWjd6IVrRv3z5cf9h+s1UAAAX5SURBVP31GB0dRXd3N3bu3Im1a9c2erMi77bbbsOPfvQjDA0Nobe3Fz09PfjBD37A/RnQ3r17sX37dqxZswbJZBIAsGrVKtx999144YUXcNNNN81oK7Zo0aJGb3IkDQ0N4corr8TU1BSklFiwYAGuu+46nHHGGTwmq7Bt2zbcc889WLduHY/HgA4cOICrrroKtm1DKYVTTjkF//AP/4AlS5ZwXwZ04MAB/P3f/z1GRkZgmiY+/elP45xzzuFruwLvfve7ccMNN+Dss8/OfY/7cTYG3UREREREIWN5CRERERFRyBh0ExERERGFjEE3EREREVHIGHQTEREREYWMQTcRERERUcgYdBMRzROXX345vv/979f0Nu+8805cc801Nb1NIqJWZDZ6A4iIKJht27ZhaGgIhmHkvvfBD34QN95445x/941vfKMOW0dERMUw6CYiakL33HMP3v72tzd6M4iIyCeWlxARtYj7778fF198MW699VZs2rQJ73nPe/D000/nfr5jxw585zvfAQDs378fl156KTZt2oQtW7bg05/+dO73XnjhBVx00UXYtGkTLrroIrzwwgu5nx04cACXXnopNm7ciMsuuwzHjx+fsQ0vvfQSLr74YmzevBkXXHABdu3aNWP7zj//fGzcuBHbtm3Dgw8+GPIeISKKDgbdREQt5Fe/+hVOOukkPPPMM/jUpz6Fv/mbv8HIyMis3/vqV7+Kd7zjHdi9ezd+9rOf4dJLLwUAjIyM4IorrsCOHTuwa9cuXHbZZbjiiitywfU111yDM844A7t27cKVV145o0Z8cHAQV1xxBf76r/8azz77LK677jp86lOfwvDwMCYnJ3Hbbbfh3/7t3/Diiy/ivvvuw/r16+u4Z4iIGotBNxFRE/rkJz+JzZs35/77z//8TwBAX18fPvrRjyIWi+F973sf3vCGN+DJJ5+c9femaaK/vx9HjhxBIpHA5s2bAQBPPvkkVq9ejQsvvBCmaWL79u1Yu3YtnnjiCfT392PPnj24+uqrEY/H8Za3vAXbtm3L3eZ//dd/4eyzz8Y555wDKSXe8Y534Mwzz8RPf/pTAICUEnv37kUqlcKSJUtw6qmn1m1/ERE1GoNuIqImdPfdd+O5557L/ffhD38YALB06VIIIXK/t2LFChw5cmTW33/uc5+D1hp/9Vd/hfe///347ne/CwA4cuQIVqxYMeN3V6xYgcHBQRw5cgTd3d1ob2+f8TNPf38/Hn300RknA88//zyOHj2K9vZ23HHHHbjvvvvwzne+Ex//+Mexb9++UPYNEVEUcSElEVELGRwchNY6F3gPDAzMyEZ7Fi9ejNtuuw0A8Nxzz+Gyyy7DW97yFixZsgT9/f0zfndgYABbt27F4sWLMTo6isnJyVzg3d/fn7uv5cuX4wMf+EDudgtt3boVW7duRSqVwle+8hV8/vOfx7e//e2a7wMioihippuIqIUMDw/j3//935HNZvHDH/4Q+/btwznnnDPr9374wx/i8OHDAIAFCxZACAEpJc455xz88Y9/xEMPPQTLsvDII4/g97//Pc4991ysXLkSZ555Ju68805kMhk899xzeOKJJ3K3ecEFF+CJJ57Az3/+c9i2jXQ6jV27duHw4cMYGhrCT37yE0xOTiIej6O9vX1Gy0MiolbHTDcRURP6xCc+MSNoffvb347zzz8fZ511Fvbv34+3ve1tWLRoEf7lX/4Fvb29s/5+z549uP322zE+Po6FCxfihhtuwEknnQS47Qhvv/123HzzzVi9ejXuuece9PX1AQD++Z//Gddddx22bNmCDRs24MILL8To6CjgZrq/9rWv4ctf/jI++9nPQkqJs846CzfffDOUUvjWt76Fa6+9FkIIrF+/HjfddFPd9hcRUaMJrbVu9EYQEVH17r//fnznO9/Bvffe2+hNISKiAiwvISIiIiIKGYNuIiIiIqKQsbyEiIiIiChkzHQTEREREYWMQTcRERERUcgYdBMRERERhYxBNxERERFRyBh0ExERERGFjEE3EREREVHI/j/fuvk/v+lhJAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 864x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "bento_obj_id": "139974490566800"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def plot_rewards(rewards):\n",
+    "    fig, ax = plt.subplots(1, 1, figsize=(12, 10));\n",
+    "    pd.Series(rewards).rolling(20).mean().plot(ax=ax);\n",
+    "    pd.Series(rewards).plot(ax=ax,alpha=0.5,color='lightblue');\n",
+    "    ax.set_xlabel('Episodes');\n",
+    "    ax.set_ylabel('Reward');\n",
+    "    plt.title('PPO on CartPole');\n",
+    "    plt.legend(['Moving Average Reward', 'Instantaneous Episode Reward'])\n",
+    "    return fig, ax\n",
+    "\n",
+    "sns.set_style('darkgrid')\n",
+    "sns.set()\n",
+    "\n",
+    "\n",
+    "plot_rewards(train_rewards)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print eval rewards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T00:02:12.264614Z",
+     "start_time": "2021-02-25T00:01:01.218034Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0224 160212.086 gymrunner.py:132] For gamma=1.0, average reward is 187.87\n",
+      "Rewards list: [200. 190. 190. 200. 200. 200. 187. 188. 198. 200. 200. 200. 200. 165.\n",
+      " 169. 200. 200. 153. 200. 176. 200. 200. 200. 161. 200. 200. 200. 200.\n",
+      " 200. 200. 200. 170. 189. 138. 200. 200. 200. 183. 200. 154. 200. 134.\n",
+      " 194. 178. 180. 170. 200. 162. 168. 200. 176. 155. 200. 182. 200. 200.\n",
+      " 200. 186. 169. 178. 150. 200. 178. 172. 154. 200. 200. 200. 154. 200.\n",
+      " 200. 192. 195. 155. 200. 200. 200. 200. 200. 157. 136. 200. 200. 200.\n",
+      " 200. 172. 200. 200. 200. 171. 200. 200. 157. 193. 145. 200. 200. 200.\n",
+      " 200. 200. 200. 200. 172. 200. 155. 200. 131. 200. 200. 200. 178. 162.\n",
+      " 184. 200. 200. 200. 175. 200. 200. 200. 200. 200. 200. 134. 200. 200.\n",
+      " 146. 200. 200. 191. 200. 200. 200. 200. 150. 194. 200. 200. 200. 200.\n",
+      " 158. 131. 161. 200. 200. 200. 165. 200. 114. 200. 200. 200. 175. 200.\n",
+      " 200. 200. 200. 123. 200. 195. 197. 200. 193. 200. 200. 200. 200. 200.\n",
+      " 200. 200. 181. 200. 190. 191. 125. 165. 200. 200. 200. 200. 200. 181.\n",
+      " 200. 200. 195. 200. 200. 200. 181. 144. 200. 200. 200. 187. 184. 200.\n",
+      " 200. 200. 142. 200.]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean reward: 187.87\n"
+     ]
+    }
+   ],
+   "source": [
+    "eval_episodes = 200\n",
+    "eval_rewards = evaluate_for_n_episodes(eval_episodes, env, agent, 500, num_processes=1).T[0]\n",
+    "mean_reward = pd.Series(eval_rewards).mean()\n",
+    "print(f'Mean reward: {mean_reward:.2f}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "anp_cloned_from": {
+   "revision_id": "351369499371280"
+  },
+  "bento_stylesheets": {
+   "bento/extensions/flow/main.css": true,
+   "bento/extensions/kernel_selector/main.css": true,
+   "bento/extensions/kernel_ui/main.css": true,
+   "bento/extensions/new_kernel/main.css": true,
+   "bento/extensions/system_usage/main.css": true,
+   "bento/extensions/theme/main.css": true
+  },
+  "kernelspec": {
+   "display_name": "alexnik (local)",
+   "language": "python",
+   "name": "alexnik_local"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/reagent/notebooks/REINFORCE_for_CartPole_Control.ipynb
+++ b/reagent/notebooks/REINFORCE_for_CartPole_Control.ipynb
@@ -12,8 +12,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:45.361540Z",
-     "start_time": "2021-02-19T01:28:37.029027Z"
+     "end_time": "2021-02-25T18:41:39.238680Z",
+     "start_time": "2021-02-25T18:41:36.874709Z"
     }
    },
    "outputs": [
@@ -21,82 +21,84 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172842.725 dataclasses.py:48] USE_VANILLA_DATACLASS: True\n",
-      "I0218 172842.726 dataclasses.py:49] ARBITRARY_TYPES_ALLOWED: True\n",
-      "W0218 172842.777 file_io.py:72] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "I0225 104138.043 dataclasses.py:48] USE_VANILLA_DATACLASS: True\n",
+      "I0225 104138.045 dataclasses.py:49] ARBITRARY_TYPES_ALLOWED: True\n",
+      "W0225 104138.056 file_io.py:72] ** fvcore version of PathManager will be deprecated soon. **\n",
       "** Please migrate to the version in iopath repo. **\n",
       "https://github.com/facebookresearch/iopath \n",
       "\n",
-      "W0218 172842.815 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "W0225 104138.062 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
       "** Please migrate to iopath. **\n",
       "\n",
-      "I0218 172842.816 io.py:19] Registered Manifold PathManager\n",
-      "W0218 172842.820 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
+      "I0225 104138.064 io.py:19] Registered Manifold PathManager\n",
+      "W0225 104138.068 manifold.py:86] ** fvcore version of PathManager will be deprecated soon. **\n",
       "** Please migrate to iopath. **\n",
       "\n",
-      "I0218 172842.821 patch.py:95] Patched torch.load, torch.save, torch.jit.load and save to handle Manifold uri\n",
-      "I0218 172843.005 registry_meta.py:19] Adding REGISTRY to type TrainingReport\n",
-      "I0218 172843.007 registry_meta.py:40] Not Registering TrainingReport to TrainingReport. Abstract method [] are not implemented.\n",
-      "I0218 172843.008 registry_meta.py:19] Adding REGISTRY to type PublishingResult\n",
-      "I0218 172843.009 registry_meta.py:40] Not Registering PublishingResult to PublishingResult. Abstract method [] are not implemented.\n",
-      "I0218 172843.011 registry_meta.py:19] Adding REGISTRY to type ValidationResult\n",
-      "I0218 172843.011 registry_meta.py:40] Not Registering ValidationResult to ValidationResult. Abstract method [] are not implemented.\n",
-      "I0218 172843.013 registry_meta.py:31] Registering NoPublishingResults to PublishingResult\n",
-      "I0218 172843.014 registry_meta.py:34] Using no_publishing_results instead of NoPublishingResults\n",
-      "I0218 172843.015 registry_meta.py:31] Registering NoValidationResults to ValidationResult\n",
-      "I0218 172843.016 registry_meta.py:34] Using no_validation_results instead of NoValidationResults\n",
-      "I0218 172843.078 registry_meta.py:31] Registering SchedulingFrequencyValidationResults to ValidationResult\n",
-      "I0218 172843.082 registry_meta.py:34] Using scheduling_frequency_validation_results instead of SchedulingFrequencyValidationResults\n",
-      "I0218 172843.084 registry_meta.py:31] Registering PDIVFilterValidationResults to ValidationResult\n",
-      "I0218 172843.085 registry_meta.py:34] Using pdiv_filter_validation_results instead of PDIVFilterValidationResults\n",
-      "I0218 172843.087 registry_meta.py:31] Registering Seq2SlateValidationResults to ValidationResult\n",
-      "I0218 172843.088 registry_meta.py:34] Using seq2slate_validation_results instead of Seq2SlateValidationResults\n",
-      "I0218 172843.089 registry_meta.py:31] Registering SchedulingFrequencyPublishingResults to PublishingResult\n",
-      "I0218 172843.090 registry_meta.py:34] Using scheduling_frequency_publishing_results instead of SchedulingFrequencyPublishingResults\n",
-      "I0218 172843.091 registry_meta.py:31] Registering PDIVFilterPublishingResults to PublishingResult\n",
-      "I0218 172843.092 registry_meta.py:34] Using pdiv_filter_publishing_results instead of PDIVFilterPublishingResults\n",
-      "I0218 172843.094 registry_meta.py:31] Registering FeedPublishingResults to PublishingResult\n",
-      "I0218 172843.095 registry_meta.py:34] Using feed_publishing_results instead of FeedPublishingResults\n",
-      "I0218 172843.097 registry_meta.py:31] Registering ScoreFblearnerPredictorPublishingResult to PublishingResult\n",
-      "I0218 172843.097 registry_meta.py:34] Using score_offline_results instead of ScoreFblearnerPredictorPublishingResult\n",
-      "I0218 172843.098 registry_meta.py:31] Registering ScoreSeq2SlateOutput to PublishingResult\n",
-      "I0218 172843.103 registry_meta.py:34] Using score_seq2slate_offline instead of ScoreSeq2SlateOutput\n",
-      "I0218 172843.105 registry_meta.py:31] Registering SlateRewardFeatureImportanceOutput to PublishingResult\n",
-      "I0218 172843.106 registry_meta.py:34] Using slate_reward_feature_importance instead of SlateRewardFeatureImportanceOutput\n",
-      "I0218 172843.109 dataclasses.py:73] Setting IdMapping.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.110 dataclasses.py:73] Setting ModelFeatureConfig.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.187 registry_meta.py:19] Adding REGISTRY to type LearningRateSchedulerConfig\n",
-      "I0218 172843.189 registry_meta.py:40] Not Registering LearningRateSchedulerConfig to LearningRateSchedulerConfig. Abstract method [] are not implemented.\n",
-      "I0218 172843.191 registry_meta.py:19] Adding REGISTRY to type OptimizerConfig\n",
-      "I0218 172843.192 registry_meta.py:40] Not Registering OptimizerConfig to OptimizerConfig. Abstract method [] are not implemented.\n",
-      "I0218 172843.193 registry_meta.py:31] Registering Adam to OptimizerConfig\n",
-      "I0218 172843.195 registry_meta.py:31] Registering SGD to OptimizerConfig\n",
-      "I0218 172843.197 registry_meta.py:31] Registering AdamW to OptimizerConfig\n",
-      "I0218 172843.198 registry_meta.py:31] Registering SparseAdam to OptimizerConfig\n",
-      "I0218 172843.200 registry_meta.py:31] Registering Adamax to OptimizerConfig\n",
-      "I0218 172843.203 registry_meta.py:31] Registering LBFGS to OptimizerConfig\n",
-      "I0218 172843.205 registry_meta.py:31] Registering Rprop to OptimizerConfig\n",
-      "I0218 172843.206 registry_meta.py:31] Registering ASGD to OptimizerConfig\n",
-      "I0218 172843.208 registry_meta.py:31] Registering Adadelta to OptimizerConfig\n",
-      "I0218 172843.209 registry_meta.py:31] Registering Adagrad to OptimizerConfig\n",
-      "I0218 172843.211 registry_meta.py:31] Registering RMSprop to OptimizerConfig\n",
-      "I0218 172843.347 dataclasses.py:73] Setting Seq2SlateNet.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.462 dataclasses.py:73] Setting CRRWeightFn.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.526 registry_meta.py:19] Adding REGISTRY to type EnvWrapper\n",
-      "I0218 172843.527 registry_meta.py:40] Not Registering EnvWrapper to EnvWrapper. Abstract method ['make', 'obs_preprocessor', 'serving_obs_preprocessor'] are not implemented.\n",
-      "I0218 172843.528 dataclasses.py:73] Setting EnvWrapper.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.540 registry_meta.py:31] Registering ChangingArms to EnvWrapper\n",
-      "I0218 172843.592 registry_meta.py:31] Registering Gym to EnvWrapper\n",
-      "I0218 172843.605 utils.py:18] Registering id=Pocman-v0, entry_point=reagent.gym.envs.pomdp.pocman:PocManEnv.\n",
-      "I0218 172843.606 utils.py:18] Registering id=StringGame-v0, entry_point=reagent.gym.envs.pomdp.string_game:StringGameEnv.\n",
-      "I0218 172843.607 utils.py:18] Registering id=LinearDynamics-v0, entry_point=reagent.gym.envs.dynamics.linear_dynamics:LinDynaEnv.\n",
-      "I0218 172843.608 utils.py:18] Registering id=PossibleActionsMaskTester-v0, entry_point=reagent.gym.envs.functionality.possible_actions_mask_tester:PossibleActionsMaskTester.\n",
-      "I0218 172843.609 utils.py:18] Registering id=StringGame-v1, entry_point=reagent.gym.envs.pomdp.string_game_v1:StringGameEnvV1.\n",
-      "I0218 172843.699 registry_meta.py:31] Registering RecSim to EnvWrapper\n",
-      "I0218 172843.700 dataclasses.py:73] Setting RecSim.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.706 registry_meta.py:31] Registering OraclePVM to EnvWrapper\n",
-      "I0218 172843.707 dataclasses.py:73] Setting OraclePVM.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172843.728 registry_meta.py:31] Registering ToyVM to EnvWrapper\n",
+      "I0225 104138.069 patch.py:95] Patched torch.load, torch.save, torch.jit.load and save to handle Manifold uri\n",
+      "I0225 104138.232 registry_meta.py:19] Adding REGISTRY to type TrainingReport\n",
+      "I0225 104138.233 registry_meta.py:40] Not Registering TrainingReport to TrainingReport. Abstract method [] are not implemented.\n",
+      "I0225 104138.234 registry_meta.py:19] Adding REGISTRY to type PublishingResult\n",
+      "I0225 104138.234 registry_meta.py:40] Not Registering PublishingResult to PublishingResult. Abstract method [] are not implemented.\n",
+      "I0225 104138.235 registry_meta.py:19] Adding REGISTRY to type ValidationResult\n",
+      "I0225 104138.236 registry_meta.py:40] Not Registering ValidationResult to ValidationResult. Abstract method [] are not implemented.\n",
+      "I0225 104138.237 registry_meta.py:31] Registering NoPublishingResults to PublishingResult\n",
+      "I0225 104138.238 registry_meta.py:34] Using no_publishing_results instead of NoPublishingResults\n",
+      "I0225 104138.239 registry_meta.py:31] Registering NoValidationResults to ValidationResult\n",
+      "I0225 104138.239 registry_meta.py:34] Using no_validation_results instead of NoValidationResults\n",
+      "I0225 104138.244 registry_meta.py:31] Registering SchedulingFrequencyValidationResults to ValidationResult\n",
+      "I0225 104138.245 registry_meta.py:34] Using scheduling_frequency_validation_results instead of SchedulingFrequencyValidationResults\n",
+      "I0225 104138.247 registry_meta.py:31] Registering PDIVFilterValidationResults to ValidationResult\n",
+      "I0225 104138.247 registry_meta.py:34] Using pdiv_filter_validation_results instead of PDIVFilterValidationResults\n",
+      "I0225 104138.249 registry_meta.py:31] Registering Seq2SlateValidationResults to ValidationResult\n",
+      "I0225 104138.249 registry_meta.py:34] Using seq2slate_validation_results instead of Seq2SlateValidationResults\n",
+      "I0225 104138.250 registry_meta.py:31] Registering SchedulingFrequencyPublishingResults to PublishingResult\n",
+      "I0225 104138.251 registry_meta.py:34] Using scheduling_frequency_publishing_results instead of SchedulingFrequencyPublishingResults\n",
+      "I0225 104138.252 registry_meta.py:31] Registering PDIVFilterPublishingResults to PublishingResult\n",
+      "I0225 104138.253 registry_meta.py:34] Using pdiv_filter_publishing_results instead of PDIVFilterPublishingResults\n",
+      "I0225 104138.254 registry_meta.py:31] Registering FeedPublishingResults to PublishingResult\n",
+      "I0225 104138.255 registry_meta.py:34] Using feed_publishing_results instead of FeedPublishingResults\n",
+      "I0225 104138.256 registry_meta.py:31] Registering ScoreFblearnerPredictorPublishingResult to PublishingResult\n",
+      "I0225 104138.257 registry_meta.py:34] Using score_offline_results instead of ScoreFblearnerPredictorPublishingResult\n",
+      "I0225 104138.258 registry_meta.py:31] Registering ScoreSeq2SlateOutput to PublishingResult\n",
+      "I0225 104138.259 registry_meta.py:34] Using score_seq2slate_offline instead of ScoreSeq2SlateOutput\n",
+      "I0225 104138.260 registry_meta.py:31] Registering IPSResult to PublishingResult\n",
+      "I0225 104138.261 registry_meta.py:34] Using learnvm_ips_result instead of IPSResult\n",
+      "I0225 104138.263 registry_meta.py:31] Registering SlateRewardFeatureImportanceOutput to PublishingResult\n",
+      "I0225 104138.264 registry_meta.py:34] Using slate_reward_feature_importance instead of SlateRewardFeatureImportanceOutput\n",
+      "I0225 104138.268 dataclasses.py:73] Setting IdMapping.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.269 dataclasses.py:73] Setting ModelFeatureConfig.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.303 registry_meta.py:19] Adding REGISTRY to type LearningRateSchedulerConfig\n",
+      "I0225 104138.304 registry_meta.py:40] Not Registering LearningRateSchedulerConfig to LearningRateSchedulerConfig. Abstract method [] are not implemented.\n",
+      "I0225 104138.306 registry_meta.py:19] Adding REGISTRY to type OptimizerConfig\n",
+      "I0225 104138.306 registry_meta.py:40] Not Registering OptimizerConfig to OptimizerConfig. Abstract method [] are not implemented.\n",
+      "I0225 104138.308 registry_meta.py:31] Registering Adam to OptimizerConfig\n",
+      "I0225 104138.309 registry_meta.py:31] Registering SGD to OptimizerConfig\n",
+      "I0225 104138.311 registry_meta.py:31] Registering AdamW to OptimizerConfig\n",
+      "I0225 104138.312 registry_meta.py:31] Registering SparseAdam to OptimizerConfig\n",
+      "I0225 104138.314 registry_meta.py:31] Registering Adamax to OptimizerConfig\n",
+      "I0225 104138.315 registry_meta.py:31] Registering LBFGS to OptimizerConfig\n",
+      "I0225 104138.317 registry_meta.py:31] Registering Rprop to OptimizerConfig\n",
+      "I0225 104138.322 registry_meta.py:31] Registering ASGD to OptimizerConfig\n",
+      "I0225 104138.324 registry_meta.py:31] Registering Adadelta to OptimizerConfig\n",
+      "I0225 104138.325 registry_meta.py:31] Registering Adagrad to OptimizerConfig\n",
+      "I0225 104138.327 registry_meta.py:31] Registering RMSprop to OptimizerConfig\n",
+      "I0225 104138.343 dataclasses.py:73] Setting Seq2SlateNet.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.359 dataclasses.py:73] Setting CRRWeightFn.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.380 registry_meta.py:19] Adding REGISTRY to type EnvWrapper\n",
+      "I0225 104138.381 registry_meta.py:40] Not Registering EnvWrapper to EnvWrapper. Abstract method ['obs_preprocessor', 'serving_obs_preprocessor', 'make'] are not implemented.\n",
+      "I0225 104138.382 dataclasses.py:73] Setting EnvWrapper.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.387 registry_meta.py:31] Registering ChangingArms to EnvWrapper\n",
+      "I0225 104138.402 registry_meta.py:31] Registering Gym to EnvWrapper\n",
+      "I0225 104138.406 utils.py:18] Registering id=Pocman-v0, entry_point=reagent.gym.envs.pomdp.pocman:PocManEnv.\n",
+      "I0225 104138.407 utils.py:18] Registering id=StringGame-v0, entry_point=reagent.gym.envs.pomdp.string_game:StringGameEnv.\n",
+      "I0225 104138.407 utils.py:18] Registering id=LinearDynamics-v0, entry_point=reagent.gym.envs.dynamics.linear_dynamics:LinDynaEnv.\n",
+      "I0225 104138.408 utils.py:18] Registering id=PossibleActionsMaskTester-v0, entry_point=reagent.gym.envs.functionality.possible_actions_mask_tester:PossibleActionsMaskTester.\n",
+      "I0225 104138.409 utils.py:18] Registering id=StringGame-v1, entry_point=reagent.gym.envs.pomdp.string_game_v1:StringGameEnvV1.\n",
+      "I0225 104138.433 registry_meta.py:31] Registering RecSim to EnvWrapper\n",
+      "I0225 104138.435 dataclasses.py:73] Setting RecSim.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.437 registry_meta.py:31] Registering OraclePVM to EnvWrapper\n",
+      "I0225 104138.437 dataclasses.py:73] Setting OraclePVM.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104138.446 registry_meta.py:31] Registering ToyVM to EnvWrapper\n",
       "\n",
       "Bad key \"axes.color_cycle\" on line 214 in\n",
       "/home/alexnik/.matplotlib/matplotlibrc.\n",
@@ -123,8 +125,8 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:45.545243Z",
-     "start_time": "2021-02-19T01:28:45.363733Z"
+     "end_time": "2021-02-25T18:41:39.429693Z",
+     "start_time": "2021-02-25T18:41:39.240892Z"
     }
    },
    "outputs": [
@@ -132,10 +134,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172845.377 env_wrapper.py:38] Env: <TimeLimit<CartPoleEnv<CartPole-v0>>>;\n",
+      "I0225 104139.247 env_wrapper.py:38] Env: <TimeLimit<CartPoleEnv<CartPole-v0>>>;\n",
       "observation_space: Box(4,);\n",
       "action_space: Discrete(2);\n",
-      "I0218 172845.379 seed.py:57] Global seed set to 0\n"
+      "I0225 104139.250 seed.py:57] Global seed set to 0\n"
      ]
     },
     {
@@ -146,7 +148,7 @@
      },
      "execution_count": 2,
      "metadata": {
-      "bento_obj_id": "139652928420000"
+      "bento_obj_id": "139934208915616"
      },
      "output_type": "execute_result"
     }
@@ -170,8 +172,8 @@
    "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:45.876319Z",
-     "start_time": "2021-02-19T01:28:45.547701Z"
+     "end_time": "2021-02-25T18:41:39.723885Z",
+     "start_time": "2021-02-25T18:41:39.432154Z"
     }
    },
    "outputs": [
@@ -179,14 +181,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172845.681 registry_meta.py:19] Adding REGISTRY to type DiscreteDQNNetBuilder\n",
-      "I0218 172845.682 registry_meta.py:40] Not Registering DiscreteDQNNetBuilder to DiscreteDQNNetBuilder. Abstract method ['build_q_network'] are not implemented.\n",
-      "I0218 172845.683 registry_meta.py:31] Registering Dueling to DiscreteDQNNetBuilder\n",
-      "I0218 172845.684 dataclasses.py:73] Setting Dueling.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172845.688 registry_meta.py:31] Registering FullyConnected to DiscreteDQNNetBuilder\n",
-      "I0218 172845.689 dataclasses.py:73] Setting FullyConnected.__post_init__ to its __post_init_post_parse__\n",
-      "I0218 172845.692 registry_meta.py:31] Registering FullyConnectedWithEmbedding to DiscreteDQNNetBuilder\n",
-      "I0218 172845.692 dataclasses.py:73] Setting FullyConnectedWithEmbedding.__post_init__ to its __post_init_post_parse__\n"
+      "I0225 104139.542 registry_meta.py:19] Adding REGISTRY to type DiscreteDQNNetBuilder\n",
+      "I0225 104139.543 registry_meta.py:40] Not Registering DiscreteDQNNetBuilder to DiscreteDQNNetBuilder. Abstract method ['build_q_network'] are not implemented.\n",
+      "I0225 104139.543 registry_meta.py:31] Registering Dueling to DiscreteDQNNetBuilder\n",
+      "I0225 104139.544 dataclasses.py:73] Setting Dueling.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104139.546 registry_meta.py:31] Registering FullyConnected to DiscreteDQNNetBuilder\n",
+      "I0225 104139.547 dataclasses.py:73] Setting FullyConnected.__post_init__ to its __post_init_post_parse__\n",
+      "I0225 104139.548 registry_meta.py:31] Registering FullyConnectedWithEmbedding to DiscreteDQNNetBuilder\n",
+      "I0225 104139.549 dataclasses.py:73] Setting FullyConnectedWithEmbedding.__post_init__ to its __post_init_post_parse__\n"
      ]
     }
    ],
@@ -207,8 +209,8 @@
    "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:46.053042Z",
-     "start_time": "2021-02-19T01:28:45.878776Z"
+     "end_time": "2021-02-25T18:41:39.905841Z",
+     "start_time": "2021-02-25T18:41:39.726095Z"
     }
    },
    "outputs": [],
@@ -234,8 +236,8 @@
    "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:46.227348Z",
-     "start_time": "2021-02-19T01:28:46.055122Z"
+     "end_time": "2021-02-25T18:41:40.079237Z",
+     "start_time": "2021-02-25T18:41:39.907857Z"
     }
    },
    "outputs": [],
@@ -263,8 +265,8 @@
    "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:50.917749Z",
-     "start_time": "2021-02-19T01:28:46.229352Z"
+     "end_time": "2021-02-25T18:41:44.651922Z",
+     "start_time": "2021-02-25T18:41:40.081054Z"
     }
    },
    "outputs": [
@@ -272,12 +274,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172848.597 gymrunner.py:132] For gamma=1.0, average reward is 18.6\n",
+      "I0225 104142.407 gymrunner.py:132] For gamma=1.0, average reward is 18.6\n",
       "Rewards list: [15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18.\n",
       " 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18. 15. 18.\n",
       " 15. 18. 15. 18. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12.\n",
       " 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12. 29. 12.\n",
-      " 29. 12. 29. 12. 29. 12. 29. 12. 17. 21. 17. 21. 17. 21. 17. 21. 17. 21.\n",
+      " 29. 12. 17. 21. 29. 12. 29. 12. 17. 21. 17. 21. 29. 12. 17. 21. 17. 21.\n",
       " 17. 21. 17. 21. 17. 21. 17. 21. 17. 21.]\n"
      ]
     }
@@ -291,7 +293,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make sure we keep track of rewards during training"
+    "Run training loop (managed by Pytorch Lightning)"
    ]
   },
   {
@@ -299,35 +301,8 @@
    "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:51.083036Z",
-     "start_time": "2021-02-19T01:28:50.919858Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "train_rewards = []\n",
-    "\n",
-    "def append_to_train_rewards(batch, *args):\n",
-    "    ep_reward = batch[\"reward\"].sum().item()\n",
-    "    train_rewards.append(ep_reward)\n",
-    "\n",
-    "reinforce_trainer.on_train_batch_start = append_to_train_rewards"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Run training loop (managed by Pytorch Lightning)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:51.257067Z",
-     "start_time": "2021-02-19T01:28:51.085755Z"
+     "end_time": "2021-02-25T18:41:44.832445Z",
+     "start_time": "2021-02-25T18:41:44.654204Z"
     }
    },
    "outputs": [
@@ -335,7 +310,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172851.087 seed.py:57] Global seed set to 0\n"
+      "I0225 104144.656 seed.py:57] Global seed set to 0\n"
      ]
     },
     {
@@ -344,9 +319,9 @@
        "0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {
-      "bento_obj_id": "139652928420000"
+      "bento_obj_id": "139934208915616"
      },
      "output_type": "execute_result"
     }
@@ -357,11 +332,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:28:51.427124Z",
-     "start_time": "2021-02-19T01:28:51.259240Z"
+     "end_time": "2021-02-25T18:41:45.015184Z",
+     "start_time": "2021-02-25T18:41:44.834628Z"
     }
    },
    "outputs": [],
@@ -374,11 +349,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:29:22.692374Z",
-     "start_time": "2021-02-19T01:28:51.429096Z"
+     "end_time": "2021-02-25T18:41:45.206743Z",
+     "start_time": "2021-02-25T18:41:45.018149Z"
     }
    },
    "outputs": [
@@ -386,9 +361,52 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 172851.442 distributed.py:54] GPU available: False, used: False\n",
-      "I0218 172851.443 distributed.py:54] TPU available: None, using: 0 TPU cores\n",
-      "I0218 172851.474 lightning.py:1381] \n",
+      "I0225 104145.027 distributed.py:54] GPU available: False, used: False\n",
+      "I0225 104145.029 distributed.py:54] TPU available: None, using: 0 TPU cores\n"
+     ]
+    }
+   ],
+   "source": [
+    "from reagent.gym.datasets.episodic_dataset import EpisodicDataset, EpisodicDatasetDataloader\n",
+    "\n",
+    "pl_trainer = pl.Trainer(max_epochs=1, deterministic=True)\n",
+    "dataset = EpisodicDataset(env=env, agent=agent, num_episodes=num_episodes, seed=0, max_steps=max_steps)\n",
+    "\n",
+    "train_rewards = []\n",
+    "class TrainRewardsExtractor(EpisodicDataset):\n",
+    "    # a wrapper around a dataset to enable logging of rewards during training\n",
+    "    def __init__(self, dataset):\n",
+    "        self.dataset = dataset\n",
+    "        \n",
+    "    def __iter__(self):\n",
+    "        for traj in iter(self.dataset):\n",
+    "            ep_reward = traj[\"reward\"].sum().item()\n",
+    "            train_rewards.append(ep_reward)\n",
+    "            yield traj\n",
+    "            \n",
+    "    def __getattr__(self, name):\n",
+    "        return getattr(self.dataset, name)\n",
+    "    \n",
+    "dataset = TrainRewardsExtractor(dataset)\n",
+    "\n",
+    "dataloader = EpisodicDatasetDataloader(dataset, num_episodes_between_updates=1, batch_size=1, num_epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-25T18:42:15.446538Z",
+     "start_time": "2021-02-25T18:41:45.209061Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0225 104145.227 lightning.py:1381] \n",
       "  | Name   | Type              | Params\n",
       "---------------------------------------------\n",
       "0 | scorer | FullyConnectedDQN | 58    \n",
@@ -402,7 +420,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 0: 100%|██████████| 175/175 [00:31<00:00,  5.64it/s, loss=-0.075, v_num=0] \n"
+      "Epoch 0: 100%|██████████| 175/175 [00:30<00:00,  5.83it/s, loss=-0.075, v_num=3] \n"
      ]
     },
     {
@@ -413,17 +431,13 @@
      },
      "execution_count": 10,
      "metadata": {
-      "bento_obj_id": "139652928420032"
+      "bento_obj_id": "139934208915648"
      },
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from reagent.gym.datasets.episodic_dataset import EpisodicDataset\n",
-    "\n",
-    "pl_trainer = pl.Trainer(max_epochs=1, deterministic=True)\n",
-    "dataset = EpisodicDataset(env=env, agent=agent, num_episodes=num_episodes, seed=0, max_steps=max_steps)\n",
-    "pl_trainer.fit(reinforce_trainer, dataset)"
+    "pl_trainer.fit(reinforce_trainer, dataloader)"
    ]
   },
   {
@@ -438,8 +452,8 @@
    "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:29:23.910088Z",
-     "start_time": "2021-02-19T01:29:22.694349Z"
+     "end_time": "2021-02-25T18:42:16.328382Z",
+     "start_time": "2021-02-25T18:42:15.448696Z"
     }
    },
    "outputs": [
@@ -447,12 +461,12 @@
      "data": {
       "text/plain": [
        "(<Figure size 864x720 with 1 Axes>,\n",
-       " <matplotlib.axes._subplots.AxesSubplot at 0x7f02c548e210>)"
+       " <matplotlib.axes._subplots.AxesSubplot at 0x7f447806d8d0>)"
       ]
      },
      "execution_count": 11,
      "metadata": {
-      "bento_obj_id": "139646499231216"
+      "bento_obj_id": "139927970772224"
      },
      "output_type": "execute_result"
     },
@@ -464,7 +478,7 @@
       ]
      },
      "metadata": {
-      "bento_obj_id": "139649876607056"
+      "bento_obj_id": "139932048217936"
      },
      "output_type": "display_data"
     }
@@ -499,8 +513,8 @@
    "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-02-19T01:30:38.198457Z",
-     "start_time": "2021-02-19T01:29:23.913616Z"
+     "end_time": "2021-02-25T18:43:32.330306Z",
+     "start_time": "2021-02-25T18:42:16.331040Z"
     }
    },
    "outputs": [
@@ -508,7 +522,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0218 173038.014 gymrunner.py:132] For gamma=1.0, average reward is 198.59\n",
+      "I0225 104332.151 gymrunner.py:132] For gamma=1.0, average reward is 198.59\n",
       "Rewards list: [200. 200. 200. 200. 200. 200. 200. 167. 200. 200. 200. 200. 200. 200.\n",
       " 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200.\n",
       " 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200. 200.\n",

--- a/reagent/training/__init__.py
+++ b/reagent/training/__init__.py
@@ -6,6 +6,7 @@ from reagent.training.cem_trainer import CEMTrainer
 from reagent.training.discrete_crr_trainer import DiscreteCRRTrainer
 from reagent.training.dqn_trainer import DQNTrainer
 from reagent.training.parametric_dqn_trainer import ParametricDQNTrainer
+from reagent.training.ppo_trainer import PPOTrainer
 from reagent.training.qrdqn_trainer import QRDQNTrainer
 from reagent.training.reagent_lightning_module import (
     ReAgentLightningModule,
@@ -32,6 +33,7 @@ from .parameters import (
     TD3TrainerParameters,
     CRRTrainerParameters,
     ReinforceTrainerParameters,
+    PPOTrainerParameters,
 )
 
 
@@ -63,4 +65,6 @@ __all__ = [
     "Trainer",
     "ReinforceTrainer",
     "ReinforceTrainerParameters",
+    "PPOTrainer",
+    "PPOTrainerParameters",
 ]

--- a/reagent/training/parameters.py
+++ b/reagent/training/parameters.py
@@ -9,6 +9,7 @@ from .discrete_crr_trainer import DiscreteCRRTrainer
 from .dqn_trainer import DQNTrainer
 from .parametric_dqn_trainer import ParametricDQNTrainer
 from .ppo_trainer import PPOTrainer
+from .ppo_trainer import PPOTrainer
 from .qrdqn_trainer import QRDQNTrainer
 from .ranking.seq2slate_trainer import Seq2SlateTrainer
 from .reinforce_trainer import ReinforceTrainer
@@ -152,8 +153,6 @@ class ReinforceTrainerParameters:
     PPOTrainer.__init__,
     blacklist=[
         "policy",
-        "optimizer",
-        "optimizer_value_net",
         "value_net",
     ],
 )

--- a/reagent/workflow/model_managers/policy_gradient/__init__.py
+++ b/reagent/workflow/model_managers/policy_gradient/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
+from .ppo import PPO
 from .reinforce import Reinforce
 
-__all__ = ["Reinforce"]
+__all__ = ["Reinforce", "PPO"]

--- a/reagent/workflow/model_managers/policy_gradient/ppo.py
+++ b/reagent/workflow/model_managers/policy_gradient/ppo.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import logging
+from typing import Dict, Optional, Tuple, List
+
+import torch
+from reagent import types as rlt
+from reagent.core.dataclasses import dataclass, field
+from reagent.gym.policies.policy import Policy
+from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
+from reagent.gym.policies.samplers.discrete_sampler import SoftmaxActionSampler
+from reagent.models.model_feature_config_provider import RawModelFeatureConfigProvider
+from reagent.net_builder.discrete_dqn.dueling import Dueling
+from reagent.net_builder.unions import (
+    DiscreteDQNNetBuilder__Union,
+    ValueNetBuilder__Union,
+)
+from reagent.parameters import NormalizationData
+from reagent.parameters import NormalizationKey
+from reagent.parameters import param_hash
+from reagent.training import PPOTrainer, PPOTrainerParameters
+from reagent.workflow.data import ReAgentDataModule
+from reagent.workflow.model_managers.model_manager import ModelManager
+from reagent.workflow.types import (
+    Dataset,
+    ModelFeatureConfigProvider__Union,
+    ReaderOptions,
+    ResourceOptions,
+    RewardOptions,
+    RLTrainingOutput,
+    TableSpec,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PPO(ModelManager):
+    __hash__ = param_hash
+
+    trainer_param: PPOTrainerParameters = field(default_factory=PPOTrainerParameters)
+    # using DQN net here because it supports `possible_actions_mask`
+    policy_net_builder: DiscreteDQNNetBuilder__Union = field(
+        # pyre-ignore
+        default_factory=lambda: DiscreteDQNNetBuilder__Union(Dueling=Dueling())
+    )
+    value_net_builder: Optional[ValueNetBuilder__Union] = None
+    state_feature_config_provider: ModelFeatureConfigProvider__Union = field(
+        # pyre-ignore
+        default_factory=lambda: ModelFeatureConfigProvider__Union(
+            raw=RawModelFeatureConfigProvider(float_feature_infos=[])
+        )
+    )
+    sampler_temperature: float = 1.0
+
+    def __post_init_post_parse__(self):
+        super().__post_init_post_parse__()
+        self.action_names = self.trainer_param.actions
+        self._policy: Optional[Policy] = None
+        assert (
+            len(self.action_names) > 1
+        ), f"PPO needs at least 2 actions. Got {self.action_names}."
+
+    # pyre-ignore
+    def build_trainer(self) -> PPOTrainer:
+        policy_net_builder = self.policy_net_builder.value
+        # pyre-ignore
+        self._policy_network = policy_net_builder.build_q_network(
+            self.state_feature_config,
+            self.state_normalization_data,
+            len(self.action_names),
+        )
+        value_net = None
+        if self.value_net_builder:
+            value_net_builder = self.value_net_builder.value  # pyre-ignore
+            value_net = value_net_builder.build_value_network(
+                self.state_normalization_data
+            )
+        trainer = PPOTrainer(
+            policy=self.create_policy(),
+            value_net=value_net,
+            **self.trainer_param.asdict(),  # pyre-ignore
+        )
+        return trainer
+
+    def create_policy(self, serving: bool = False):
+        if serving:
+            return create_predictor_policy_from_model(self.build_serving_module())
+        else:
+            if self._policy is None:
+                sampler = SoftmaxActionSampler(temperature=self.sampler_temperature)
+                # pyre-ignore
+                self._policy = Policy(scorer=self._policy_network, sampler=sampler)
+            return self._policy
+
+    def build_serving_module(self) -> torch.nn.Module:
+        assert self._policy_network is not None
+        policy_serving_module = self.policy_net_builder.value.build_serving_module(
+            q_network=self._policy_network,
+            state_normalization_data=self.state_normalization_data,
+            action_names=self.action_names,
+            state_feature_config=self.state_feature_config,
+        )
+        return policy_serving_module
+
+    def run_feature_identification(
+        self, input_table_spec: TableSpec
+    ) -> Dict[str, NormalizationData]:
+        raise NotImplementedError
+
+    @property
+    def required_normalization_keys(self) -> List[str]:
+        return [NormalizationKey.STATE]
+
+    @property
+    def should_generate_eval_dataset(self) -> bool:
+        raise NotImplementedError
+
+    def query_data(
+        self,
+        input_table_spec: TableSpec,
+        sample_range: Optional[Tuple[float, float]],
+        reward_options: RewardOptions,
+    ) -> Dataset:
+        raise NotImplementedError
+
+    def train(
+        self,
+        train_dataset: Optional[Dataset],
+        eval_dataset: Optional[Dataset],
+        data_module: Optional[ReAgentDataModule],
+        num_epochs: int,
+        reader_options: ReaderOptions,
+        resource_options: Optional[ResourceOptions],
+    ) -> RLTrainingOutput:
+        raise NotImplementedError
+
+    @property
+    def state_feature_config(self) -> rlt.ModelFeatureConfig:
+        return self.state_feature_config_provider.value.get_model_feature_config()


### PR DESCRIPTION
Summary:
Implementation notes:
1. I had to create a Dataloader to handle the buildup of the trajectory buffer for PPO.
2. PPO operates on batches of trajectories. I chose to implement the batches in the simplest (but probably inefficient) way - as lists of trajectories.
3. Distributed training will not work for this implementation. I don't think it's a high priority for PPO right now, so we can implement it when it's necessary. Since PPO is an online algorithm, it would actually need a different approach than what we do for offline (batch) RL.
4. I made a change to `ReAgentLightningModule` to enable automatic conversion of not only dictionaries, but also lists of dictionaries (a list represents a batch)

Differential Revision: D26651755

