### PR TITLE
@final is only supported for python3.8

### DIFF
--- a/reagent/training/reagent_lightning_module.py
+++ b/reagent/training/reagent_lightning_module.py
@@ -2,12 +2,12 @@
 
 import inspect
 import logging
-from typing import final
 
 import pytorch_lightning as pl
 import torch
 from reagent.core.tensorboardX import SummaryWriterContext
 from reagent.core.utils import lazy_property
+from typing_extensions import final
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Summary: we need to import final from typing_extensions

Reviewed By: MisterTea

Differential Revision: D26993309

