### PR TITLE
Remove manifold_tb_logger_name argument from train_eval_lightning call in discrete_dqn_base.py

### DIFF
--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -179,7 +179,7 @@ class DiscreteDQNBase(ModelManager):
             reader_options=reader_options,
             checkpoint_path=self._lightning_checkpoint_path,
             resource_options=resource_options,
-            manifold_tb_logger_name="DQN_base",
+            # manifold_tb_logger_name="DQN_base",
         )
         rank = get_rank()
         if rank == 0:


### PR DESCRIPTION
Differential Revision: D27612833

