### PR TITLE
Clone dqn reporter logging on tensorboard

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -240,7 +240,7 @@ Now we are ready to train a model by running:
 .. code-block::
 
     # make preprocessor from the normalization parameters of Step 3
-    batch_preprocessor = manager.build_batch_preprocessor()
+    batch_preprocessor = manager.build_batch_preprocessor(use_gpu)
 
     # read preprocessed data
     data_reader = petastorm.make_batch_reader(train_dataset.parquet_url)

--- a/reagent/core/oss_tensorboard_logger.py
+++ b/reagent/core/oss_tensorboard_logger.py
@@ -1,0 +1,129 @@
+from typing import Optional, Union, Dict, List, Tuple
+
+import torch
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.utilities import rank_zero_only
+
+
+class LocalCacheLogger:
+    @staticmethod
+    def store_metrics(
+        tb_logger,
+        metrics: Dict[
+            str, Union[float, torch.Tensor, Dict[str, Union[float, torch.Tensor]]]
+        ],
+        step: Optional[int] = None,
+    ):
+        for plot_name, plot_value_or_dict in metrics.items():
+            if isinstance(plot_value_or_dict, dict):
+                if plot_name not in tb_logger.line_plot_buffer:
+                    tb_logger.line_plot_buffer[plot_name] = {}
+                for line_name, plot_value in plot_value_or_dict.items():
+                    LocalCacheLogger._add_point(
+                        tb_logger, plot_name, line_name, plot_value, step
+                    )
+            else:
+                LocalCacheLogger._add_point(
+                    tb_logger, plot_name, "", plot_value_or_dict, step
+                )
+
+    @staticmethod
+    def _add_point(
+        tb_logger,
+        plot_name: str,
+        line_name: str,
+        plot_value: Union[float, torch.Tensor],
+        step: Optional[int],
+    ):
+        """ Adds a point to a multi-line plot given the plot name, the line name, and optionally the step (x coordinate). """
+        if isinstance(plot_value, torch.Tensor):
+            plot_value = plot_value.item()
+
+        if step is None:
+            if (
+                plot_name in tb_logger.line_plot_buffer
+                and line_name in tb_logger.line_plot_buffer[plot_name]
+            ):
+                x = tb_logger.line_plot_buffer[plot_name][line_name][-1][0] + 1.0
+            else:
+                x = 0.0
+        else:
+            x = float(step)
+
+        LocalCacheLogger._create_plots_and_append(
+            tb_logger.line_plot_buffer, plot_name, line_name, x, plot_value
+        )
+
+        if len(tb_logger.line_plot_buffer[plot_name][line_name]) >= 50:
+            mean = float(
+                torch.mean(
+                    torch.FloatTensor(
+                        [
+                            float(p[1])
+                            for p in tb_logger.line_plot_buffer[plot_name][line_name]
+                        ]
+                    )
+                ).item()
+            )
+            LocalCacheLogger._create_plots_and_append(
+                tb_logger.line_plot_aggregated, plot_name, line_name, x, mean
+            )
+            tb_logger.line_plot_buffer[plot_name][line_name].clear()
+
+    @staticmethod
+    def _create_plots_and_append(
+        plot_store: Dict[str, Dict[str, List[Tuple[float, float]]]],
+        plot_name: str,
+        line_name: str,
+        x: int,
+        y: float,
+    ):
+        if plot_name in plot_store and line_name in plot_store[plot_name]:
+            plot_store[plot_name][line_name].append((x, y))
+        elif plot_name in plot_store:
+            plot_store[plot_name][line_name] = [(x, y)]
+        else:
+            plot_store[plot_name] = {line_name: [(x, y)]}
+
+
+class OssTensorboardLogger(TensorBoardLogger):
+    """ Wrapper around ManifoldTensorBoardLogger that collects the plot data in memory and can flush to create fblearner plot objects. """
+
+    def __init__(
+        self,
+        save_dir: str,
+        name: Optional[str] = "default",
+        version: Optional[Union[int, str]] = None,
+        log_graph: bool = False,
+        default_hp_metric: bool = True,
+        prefix: str = "",
+        **kwargs
+    ):
+        super().__init__(
+            save_dir,
+            name,
+            version,
+            log_graph,
+            default_hp_metric,
+            prefix,
+            **kwargs,
+        )
+        self.line_plot_aggregated: Dict[str, Dict[str, List[Tuple[float, float]]]] = {}
+        self.line_plot_buffer: Dict[str, Dict[str, List[Tuple[float, float]]]] = {}
+
+    @rank_zero_only
+    def log_metrics(
+        self,
+        metrics: Dict[
+            str, Union[float, torch.Tensor, Dict[str, Union[float, torch.Tensor]]]
+        ],
+        step: Optional[int] = None,
+    ) -> None:
+        """ Log a set of metrics. A metric is either a scalar or a set of scalars that will be plotted together """
+        super().log_metrics(metrics, step)
+        LocalCacheLogger.store_metrics(self, metrics, step)
+
+    def clear_local_data(self):
+        # We don't call clear here because it's a lot of data and someone else probably owns it
+        self.line_plot_aggregated = {}
+        self.line_plot_buffer = {}

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -215,19 +215,19 @@ class ActorCriticBase(ModelManager):
             sample_range=sample_range,
         )
 
-    def build_batch_preprocessor(self) -> BatchPreprocessor:
+    def build_batch_preprocessor(self, use_gpu: bool) -> BatchPreprocessor:
         state_preprocessor = Preprocessor(
             self.state_normalization_data.dense_normalization_parameters,
-            use_gpu=self.use_gpu,
+            use_gpu=use_gpu,
         )
         action_preprocessor = Preprocessor(
             self.action_normalization_data.dense_normalization_parameters,
-            use_gpu=self.use_gpu,
+            use_gpu=use_gpu,
         )
         return PolicyNetworkBatchPreprocessor(
             state_preprocessor=state_preprocessor,
             action_preprocessor=action_preprocessor,
-            use_gpu=self.use_gpu,
+            use_gpu=use_gpu,
         )
 
     def get_reporter(self):
@@ -244,8 +244,9 @@ class ActorCriticBase(ModelManager):
         reader_options: ReaderOptions,
         resource_options: Optional[ResourceOptions],
     ) -> RLTrainingOutput:
+        use_gpu = next(self.trainer.parameters()).is_cuda
 
-        batch_preprocessor = self.build_batch_preprocessor()
+        batch_preprocessor = self.build_batch_preprocessor(use_gpu)
         reporter = self.get_reporter()
         # pyre-fixme[16]: `Trainer` has no attribute `set_reporter`.
         # pyre-fixme[16]: `Trainer` has no attribute `set_reporter`.
@@ -261,7 +262,7 @@ class ActorCriticBase(ModelManager):
             trainer_module=self.trainer,
             data_module=data_module,
             num_epochs=num_epochs,
-            use_gpu=self.use_gpu,
+            use_gpu=use_gpu,
             logger_name="ActorCritic",
             batch_preprocessor=batch_preprocessor,
             reader_options=self.reader_options,

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -187,7 +187,11 @@ class DiscreteDQNBase(ModelManager):
             training_report = RLTrainingReport.make_union_instance(
                 reporter.generate_training_report()
             )
-            return RLTrainingOutput(training_report=training_report)
+            logger_data = self._lightning_trainer.logger.line_plot_aggregated
+            self._lightning_trainer.logger.clear_local_data()
+            return RLTrainingOutput(
+                training_report=training_report, logger_data=logger_data
+            )
         # Output from processes with non-0 rank is not used
         return RLTrainingOutput()
 

--- a/reagent/training/dqn_trainer_base.py
+++ b/reagent/training/dqn_trainer_base.py
@@ -89,7 +89,8 @@ class DQNTrainerBaseLightning(DQNTrainerMixin, RLTrainerMixin, ReAgentLightningM
         self.calc_cpe_in_training = (
             evaluation_parameters and evaluation_parameters.calc_cpe_in_training
         )
-        self._actions = actions
+        assert actions is not None
+        self._actions: List[str] = actions
 
         if rl_parameters.q_network_loss == "mse":
             self.q_network_loss = F.mse_loss
@@ -110,7 +111,6 @@ class DQNTrainerBaseLightning(DQNTrainerMixin, RLTrainerMixin, ReAgentLightningM
     @property
     def num_actions(self) -> int:
         assert self._actions is not None, "Not a discrete action DQN"
-        # pyre-fixme[6]: Expected `Sized` for 1st param but got `Optional[List[str]]`.
         return len(self._actions)
 
     # pyre-fixme[56]: Decorator `torch.no_grad(...)` could not be called, because

--- a/reagent/workflow/types.py
+++ b/reagent/workflow/types.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
 from datetime import datetime as RecurringPeriod  # noqa
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 # Triggering registration to registries
 import reagent.core.result_types  # noqa
@@ -111,6 +111,9 @@ class RLTrainingOutput:
     validation_result: Optional[ValidationResult__Union] = None
     publishing_result: Optional[PublishingResult__Union] = None
     training_report: Optional[RLTrainingReport] = None
+    logger_data: Dict[str, Dict[str, List[Tuple[float, float]]]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass

--- a/reagent/workflow/utils.py
+++ b/reagent/workflow/utils.py
@@ -13,7 +13,7 @@ from petastorm import make_batch_reader
 # pyre-fixme[21]: Could not find module `petastorm.pytorch`.
 # pyre-fixme[21]: Could not find module `petastorm.pytorch`.
 from petastorm.pytorch import DataLoader, decimal_friendly_collate
-from pytorch_lightning.loggers import TensorBoardLogger
+from reagent.core.oss_tensorboard_logger import OssTensorboardLogger
 from reagent.data.spark_utils import get_spark_session
 from reagent.preprocessing.batch_preprocessor import BatchPreprocessor
 from reagent.training import StoppingEpochCallback
@@ -132,7 +132,7 @@ def train_eval_lightning(
         train_dataset, eval_dataset, batch_preprocessor, reader_options
     )
     trainer = pl.Trainer(
-        logger=TensorBoardLogger(save_dir="pl_log_tensorboard", name=logger_name),
+        logger=OssTensorboardLogger(save_dir="pl_log_tensorboard", name=logger_name),
         max_epochs=num_epochs * 1000,
         gpus=int(use_gpu),
         reload_dataloaders_every_epoch=True,


### PR DESCRIPTION
Summary: This diff uses the logger in pytorch lightning to recreate the graphs that were traditionally reported through the dqn_reporter.  These graphs are then fed back into fblearner, eliiminating the need to report them manually.

Differential Revision: D27694627

