### PR TITLE
Move batch_size of trainer_param to mini_batchsize of reader_options

### DIFF
--- a/reagent/core/parameters.py
+++ b/reagent/core/parameters.py
@@ -79,7 +79,6 @@ class Seq2RewardTrainerParameters(BaseDataClass):
     learning_rate: float = 0.001
     multi_steps: int = 1
     action_names: List[str] = field(default_factory=lambda: [])
-    batch_size: int = 1024
     compress_model_batch_size: int = 32
     compress_model_learning_rate: float = 0.001
     gamma: float = 1.0

--- a/reagent/test/world_model/test_seq2reward.py
+++ b/reagent/test/world_model/test_seq2reward.py
@@ -204,7 +204,6 @@ def train_and_eval_seq2reward_model(
         learning_rate=0.01,
         multi_steps=SEQ_LEN,
         action_names=["0", "1"],
-        batch_size=batch_size,
         gamma=1.0,
         view_q_value=True,
     )

--- a/reagent/training/world_model/seq2reward_trainer.py
+++ b/reagent/training/world_model/seq2reward_trainer.py
@@ -79,7 +79,6 @@ class Seq2RewardTrainer(ReAgentLightningModule):
         super().__init__()
         self.seq2reward_network = seq2reward_network
         self.params = params
-        self.minibatch_size = self.params.batch_size
 
         # Turning off Q value output during training:
         self.view_q_value = params.view_q_value


### PR DESCRIPTION
Summary: Move the batch_size for training seq2reward `trainer_param` to `reader_options`.

Differential Revision: D27720626

