### PR TITLE
Computing numbers needed for CFEval in validation_step

### DIFF
--- a/reagent/evaluation/doubly_robust_estimator.py
+++ b/reagent/evaluation/doubly_robust_estimator.py
@@ -131,6 +131,7 @@ class DoublyRobustEstimator:
         if edp.contexts is None:
             raise ValueError("contexts not provided in input")
         contexts_dict = {
+            # pyre-ignore [16]: `Optional` has no attribute `__getitem__`
             "train": edp.contexts[idx_train],
             "valid": edp.contexts[idx_valid],
             "eval": edp.contexts[idx_eval],

--- a/reagent/evaluation/evaluator.py
+++ b/reagent/evaluation/evaluator.py
@@ -93,11 +93,13 @@ class Evaluator:
 
         if self.action_names is not None:
             if edp.optimal_q_values is not None:
+                # pyre-ignore [16]: `Optional` has no attribute `mean`
                 value_means = edp.optimal_q_values.mean(dim=0)
                 cpe_details.q_value_means = {
                     action: float(value_means[i])
                     for i, action in enumerate(self.action_names)
                 }
+                # pyre-ignore [16]: `Optional` has no attribute `std`
                 value_stds = edp.optimal_q_values.std(dim=0)
                 cpe_details.q_value_stds = {
                     action: float(value_stds[i])
@@ -105,10 +107,9 @@ class Evaluator:
                 }
             if edp.eval_action_idxs is not None:
                 cpe_details.action_distribution = {
-                    # pyre-fixme[6]: Expected `Union[_SupportsIndex, bytearray,
-                    #  bytes, str, typing.SupportsFloat]` for 1st param but got
-                    #  `ByteTensor`.
+                    # pyre-ignore [16]: `bool` has no attribute `sum`
                     action: float((edp.eval_action_idxs == i).sum())
+                    # pyre-ignore [16]: `Optional` has no attribute `shape`
                     / edp.eval_action_idxs.shape[0]
                     for i, action in enumerate(self.action_names)
                 }

--- a/reagent/evaluation/ope_adapter.py
+++ b/reagent/evaluation/ope_adapter.py
@@ -69,6 +69,7 @@ class OPEstimatorAdapter:
                 logged_propensities[action] = edp.logged_propensities[idx]
             log.append(
                 LogSample(
+                    # pyre-ignore [16]: Optional type has no attribute `__getitem__`
                     context=None if edp.contexts is None else edp.contexts[idx],
                     log_action=Action(action),
                     log_reward=edp.logged_rewards[idx],
@@ -156,6 +157,7 @@ class SequentialOPEstimatorAdapter:
             edp.logged_rewards.cpu().numpy().flatten(),
             edp.logged_propensities.cpu().numpy().flatten(),
             edp.model_propensities.cpu().numpy(),
+            # pyre-ignore [16]: Optional type has no attribute `cpu`
             edp.model_values.cpu().numpy(),
         )
 

--- a/reagent/evaluation/sequential_doubly_robust_estimator.py
+++ b/reagent/evaluation/sequential_doubly_robust_estimator.py
@@ -68,6 +68,7 @@ class SequentialDoublyRobustEstimator:
         last_episode_end = -1
         while i < num_examples:
             # calculate the doubly-robust Q-value for one episode
+            # pyre-ignore [16]: Optional type has no attribute `__getitem__`
             if i == num_examples - 1 or edp.mdp_id[i] != edp.mdp_id[i + 1]:
                 episode_end = i
                 episode_value = 0.0

--- a/reagent/evaluation/weighted_sequential_doubly_robust_estimator.py
+++ b/reagent/evaluation/weighted_sequential_doubly_robust_estimator.py
@@ -44,6 +44,7 @@ class WeightedSequentialDoublyRobustEstimator:
             edp.logged_rewards.cpu().numpy().flatten(),
             edp.logged_propensities.cpu().numpy().flatten(),
             edp.model_propensities.cpu().numpy(),
+            # pyre-ignore [16]: Optional type has no attribute `cpu`
             edp.model_values.cpu().numpy(),
         )
 

--- a/reagent/training/discrete_crr_trainer.py
+++ b/reagent/training/discrete_crr_trainer.py
@@ -344,8 +344,9 @@ class DiscreteCRRTrainer(DQNTrainerBaseLightning):
 
         # RETURN ARGS:
         # The super() call at the end of this function calls the function with the same name
-        # in dqn_trainer_base.py, which simply returns the batch.cpu(). In other words,
-        # the validation_epoch_end() function will be called on a list of validation batches.
+        # in dqn_trainer_base.py, which returns a EvaluationDataPage for data in that batch.
+        # In other words, the validation_epoch_end() function will take a list of validation
+        # EvaluationDataPages.
 
         # validation data
         state = batch.state


### PR DESCRIPTION
Summary: OOM issues can occur in CFEval of DQN and CRR workflows when the validation set is too large. This diff solves this issue by computing the numbers needed for CFEval in `validation_step`, instead of just stacking the batches, which include all the state features that can take a lot of memory.

Differential Revision: D27929283

