### PR TITLE
Add ngram synthetic reward network.

### DIFF
--- a/reagent/models/synthetic_reward.py
+++ b/reagent/models/synthetic_reward.py
@@ -6,6 +6,7 @@ from typing import List
 import torch
 import torch.nn as nn
 from reagent.core import types as rlt
+from reagent.models import fully_connected_network
 from reagent.models.base import ModelBase
 from reagent.models.fully_connected_network import ACTIVATION_MAP
 
@@ -29,6 +30,26 @@ class SequentialMultiArguments(nn.Sequential):
             else:
                 inputs = module(inputs)
         return inputs
+
+
+def _gen_mask(valid_step: torch.Tensor, batch_size: int, seq_len: int):
+    """
+    Mask for dealing with different lengths of MDPs
+
+    Example:
+    valid_step = [[1], [2], [3]], batch_size=3, seq_len = 4
+    mask = [
+        [0, 0, 0, 1],
+        [0, 0, 1, 1],
+        [0, 1, 1, 1],
+    ]
+    """
+    assert valid_step.shape == (batch_size, 1)
+    assert ((1 <= valid_step) <= seq_len).all()
+    device = valid_step.device
+    mask = torch.arange(seq_len, device=device).repeat(batch_size, 1)
+    mask = (mask >= (seq_len - valid_step)).float()
+    return mask
 
 
 class SingleStepSyntheticRewardNet(ModelBase):
@@ -55,25 +76,6 @@ class SingleStepSyntheticRewardNet(ModelBase):
         modules.append(ACTIVATION_MAP[last_layer_activation]())
         self.dnn = SequentialMultiArguments(*modules)
 
-    def gen_mask(self, valid_step: torch.Tensor, batch_size: int, seq_len: int):
-        """
-        Mask for dealing with different lengths of MDPs
-
-        Example:
-        valid_step = [[1], [2], [3]], batch_size=3, seq_len = 4
-        mask = [
-            [0, 0, 0, 1],
-            [0, 0, 1, 1],
-            [0, 1, 1, 1],
-        ]
-        """
-        assert valid_step.shape == (batch_size, 1)
-        assert ((1 <= valid_step) <= seq_len).all()
-        device = valid_step.device
-        mask = torch.arange(seq_len, device=device).repeat(batch_size, 1)
-        mask = (mask >= (seq_len - valid_step)).float()
-        return mask
-
     def forward(self, training_batch: rlt.MemoryNetworkInput):
         # state shape: seq_len, batch_size, state_dim
         state = training_batch.state
@@ -88,7 +90,7 @@ class SingleStepSyntheticRewardNet(ModelBase):
         # pyre-fixme[29]: `SequentialMultiArguments` is not a function.
         output = self.dnn(state, action).squeeze(2).transpose(0, 1)
         assert valid_step is not None
-        mask = self.gen_mask(valid_step, batch_size, seq_len)
+        mask = _gen_mask(valid_step, batch_size, seq_len)
         output *= mask
 
         pred_reward = output.sum(dim=1, keepdim=True)
@@ -96,3 +98,90 @@ class SingleStepSyntheticRewardNet(ModelBase):
 
     def export_mlp(self):
         return self.dnn
+
+
+class NGramSyntheticRewardNet(ModelBase):
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        sizes: List[int],
+        activations: List[str],
+        last_layer_activation: str,
+        context_size: int,
+        use_batch_norm: bool = False,
+        use_layer_norm: bool = False,
+    ):
+        """
+        Decompose rewards at the last step to individual steps.
+        """
+        super().__init__()
+
+        assert context_size % 2 == 1, f"Context size is not odd: {context_size}"
+
+        self.state_dim = state_dim
+        self.action_dim = action_dim
+        self.context_size = context_size
+
+        self.ngram_padding = torch.zeros(1, 1, state_dim + action_dim)
+
+        self.fc = fully_connected_network.FullyConnectedNetwork(
+            [(state_dim + action_dim) * context_size] + sizes + [1],
+            activations + [last_layer_activation],
+            use_batch_norm=use_batch_norm,
+            use_layer_norm=use_layer_norm,
+        )
+
+    def _ngram(self, input):
+        seq_len, batch_size, feature_dim = input.shape
+
+        shifted_list = []
+        for i in range(self.context_size):
+            offset = i - self.context_size // 2
+            if offset < 0:
+                shifted = torch.cat(
+                    (
+                        self.ngram_padding.tile((-offset, batch_size, 1)),
+                        input.narrow(0, 0, seq_len + offset),
+                    ),
+                    dim=0,
+                )
+            elif offset > 0:
+                shifted = torch.cat(
+                    (
+                        input.narrow(0, offset, seq_len - offset),
+                        self.ngram_padding.tile(offset, batch_size, 1),
+                    ),
+                    dim=0,
+                )
+            else:
+                shifted = input
+            shifted_list.append(shifted)
+
+        # shape: seq_len, batch_size, feature_dim * context_size
+        return torch.cat(shifted_list, -1)
+
+    def forward(self, training_batch: rlt.MemoryNetworkInput):
+        # state shape: seq_len, batch_size, state_dim
+        state = training_batch.state
+        # action shape: seq_len, batch_size, action_dim
+        action = rlt.FeatureData(float_features=training_batch.action)
+
+        # shape: seq_len, batch_size, state_dim + action_dim
+        cat_input = torch.cat((state.float_features, action.float_features), dim=-1)
+
+        # shape: seq_len, batch_size, (state_dim + action_dim) * context_size
+        ngram = self._ngram(cat_input)
+
+        # shape: batch_size, 1
+        valid_step = training_batch.valid_step
+        seq_len, batch_size, _ = training_batch.action.shape
+
+        # output shape: batch_size, seq_len
+        output = self.fc(ngram).squeeze(2).transpose(0, 1)
+        assert valid_step is not None
+        mask = _gen_mask(valid_step, batch_size, seq_len)
+        output *= mask
+
+        pred_reward = output.sum(dim=1, keepdim=True)
+        return rlt.RewardNetworkOutput(predicted_reward=pred_reward)

--- a/reagent/net_builder/synthetic_reward/ngram_synthetic_reward.py
+++ b/reagent/net_builder/synthetic_reward/ngram_synthetic_reward.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from typing import List, Optional
+
+import torch
+from reagent.core.dataclasses import dataclass, field
+from reagent.core.parameters import NormalizationData, param_hash
+from reagent.models.base import ModelBase
+from reagent.models.synthetic_reward import NGramSyntheticRewardNet
+from reagent.net_builder.synthetic_reward_net_builder import SyntheticRewardNetBuilder
+from reagent.preprocessing.normalization import get_num_output_features
+
+
+@dataclass
+class NGramSyntheticReward(SyntheticRewardNetBuilder):
+    __hash__ = param_hash
+
+    sizes: List[int] = field(default_factory=lambda: [256, 128])
+    activations: List[str] = field(default_factory=lambda: ["relu", "relu"])
+    last_layer_activation: str = "sigmoid"
+    context_size: int = 3
+
+    def build_synthetic_reward_network(
+        self,
+        state_normalization_data: NormalizationData,
+        action_normalization_data: Optional[NormalizationData] = None,
+        discrete_action_names: Optional[List[str]] = None,
+    ) -> ModelBase:
+        state_dim = get_num_output_features(
+            state_normalization_data.dense_normalization_parameters
+        )
+        if not discrete_action_names:
+            assert action_normalization_data is not None
+            action_dim = get_num_output_features(
+                action_normalization_data.dense_normalization_parameters
+            )
+        else:
+            action_dim = len(discrete_action_names)
+        return NGramSyntheticRewardNet(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            sizes=self.sizes,
+            activations=self.activations,
+            last_layer_activation=self.last_layer_activation,
+            context_size=self.context_size,
+        )
+
+    def build_serving_module(
+        self,
+        synthetic_reward_network: ModelBase,
+        state_normalization_data: NormalizationData,
+        action_normalization_data: Optional[NormalizationData] = None,
+        discrete_action_names: Optional[List[str]] = None,
+    ) -> torch.nn.Module:
+        """
+        Returns a TorchScript predictor module
+        """
+        raise NotImplementedError(
+            "N-gram Synthetic Reward Predictor has not been implemented"
+        )

--- a/reagent/net_builder/unions.py
+++ b/reagent/net_builder/unions.py
@@ -28,6 +28,9 @@ from .parametric_dqn.fully_connected import (
 )
 from .quantile_dqn.dueling_quantile import DuelingQuantile as DuelingQuantileType
 from .quantile_dqn.quantile import Quantile as QuantileType
+from .synthetic_reward.ngram_synthetic_reward import (
+    NGramSyntheticReward as NGramSyntheticRewardType,
+)
 from .synthetic_reward.single_step_synthetic_reward import (
     SingleStepSyntheticReward as SingleStepSyntheticRewardType,
 )
@@ -79,3 +82,4 @@ class ValueNetBuilder__Union(TaggedUnion):
 @wrap_oss_with_dataclass
 class SyntheticRewardNetBuilder__Union(TaggedUnion):
     SingleStepSyntheticReward: Optional[SingleStepSyntheticRewardType] = None
+    NGramSyntheticReward: Optional[NGramSyntheticRewardType] = None

--- a/reagent/test/models/test_synthetic_reward_net.py
+++ b/reagent/test/models/test_synthetic_reward_net.py
@@ -5,6 +5,8 @@ import logging
 import unittest
 
 import torch
+from reagent.models import synthetic_reward
+from reagent.models.synthetic_reward import NGramSyntheticRewardNet
 from reagent.models.synthetic_reward import SingleStepSyntheticRewardNet
 
 
@@ -40,7 +42,44 @@ class TestSyntheticReward(unittest.TestCase):
         valid_step = torch.tensor([[1], [2], [3]])
         batch_size = 3
         seq_len = 4
-        mask = reward_net.gen_mask(valid_step, batch_size, seq_len)
+        mask = synthetic_reward._gen_mask(valid_step, batch_size, seq_len)
+        assert torch.all(
+            mask
+            == torch.tensor(
+                [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 1.0], [0.0, 1.0, 1.0, 1.0]]
+            )
+        )
+
+    def test_ngram_synthetic_reward(self):
+        state_dim = 10
+        action_dim = 2
+        sizes = [256, 128]
+        activations = ["sigmoid", "relu"]
+        last_layer_activation = "leaky_relu"
+        context_size = 3
+        reward_net = NGramSyntheticRewardNet(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            sizes=sizes,
+            activations=activations,
+            last_layer_activation=last_layer_activation,
+            context_size=context_size,
+        )
+        dnn = reward_net.fc.dnn
+        assert dnn[0].in_features == (state_dim + action_dim) * context_size
+        assert dnn[0].out_features == 256
+        assert dnn[1]._get_name() == "Sigmoid"
+        assert dnn[2].in_features == 256
+        assert dnn[2].out_features == 128
+        assert dnn[3]._get_name() == "ReLU"
+        assert dnn[4].in_features == 128
+        assert dnn[4].out_features == 1
+        assert dnn[5]._get_name() == "LeakyReLU"
+
+        valid_step = torch.tensor([[1], [2], [3]])
+        batch_size = 3
+        seq_len = 4
+        mask = synthetic_reward._gen_mask(valid_step, batch_size, seq_len)
         assert torch.all(
             mask
             == torch.tensor(

--- a/reagent/test/net_builder/test_synthetic_reward_net_builder.py
+++ b/reagent/test/net_builder/test_synthetic_reward_net_builder.py
@@ -7,6 +7,9 @@ import torch
 from reagent.core import types as rlt
 from reagent.core.fb_checker import IS_FB_ENVIRONMENT
 from reagent.core.parameters import NormalizationData, NormalizationParameters
+from reagent.net_builder.synthetic_reward.ngram_synthetic_reward import (
+    NGramSyntheticReward,
+)
 from reagent.net_builder.synthetic_reward.single_step_synthetic_reward import (
     SingleStepSyntheticReward,
 )
@@ -114,3 +117,29 @@ class TestSyntheticRewardNetBuilder(unittest.TestCase):
         self.assertIsInstance(
             predictor_wrapper, ParametricSingleStepSyntheticRewardPredictorWrapper
         )
+
+    def test_ngram_synthetic_reward_net_builder_continuous_actions(
+        self,
+    ):
+        builder = SyntheticRewardNetBuilder__Union(
+            NGramSyntheticReward=NGramSyntheticReward()
+        ).value
+        state_normalization_data = _create_norm(STATE_DIM)
+        action_normalization_data = _create_norm(ACTION_DIM, offset=STATE_DIM)
+        reward_net = builder.build_synthetic_reward_network(
+            state_normalization_data,
+            action_normalization_data=action_normalization_data,
+        )
+        input = _create_input()
+        output = reward_net(input).predicted_reward
+        assert output.shape == (BATCH_SIZE, 1)
+
+        # TO IMPLEMENT
+        # predictor_wrapper = builder.build_serving_module(
+        #     reward_net,
+        #     state_normalization_data,
+        #     action_normalization_data=action_normalization_data,
+        # )
+        # self.assertIsInstance(
+        #     predictor_wrapper, ParametricSingleStepSyntheticRewardPredictorWrapper
+        # )

--- a/reagent/test/training/test_synthetic_reward_training.py
+++ b/reagent/test/training/test_synthetic_reward_training.py
@@ -7,6 +7,7 @@ import unittest
 import pytorch_lightning as pl
 import torch
 from reagent.core import types as rlt
+from reagent.models import synthetic_reward
 from reagent.models.synthetic_reward import SingleStepSyntheticRewardNet
 from reagent.optimizer.union import Optimizer__Union
 from reagent.optimizer.union import classes
@@ -81,6 +82,45 @@ class TestSyntheticRewardTraining(unittest.TestCase):
             state_dim, action_dim, seq_len, batch_size, num_batches
         )
         threshold = 0.1
+        reach_threshold = False
+        for batch in data_generator():
+            loss = trainer.train(batch)
+            if loss < threshold:
+                reach_threshold = True
+                break
+
+        assert reach_threshold, f"last loss={loss}"
+
+    def test_ngram_fc_parametric_reward(self):
+        """
+        Reward at each step is a linear function of states and actions in a
+        context window around the step.
+
+        However, we can only observe aggregated reward at the last step
+        """
+        state_dim = 10
+        action_dim = 2
+        seq_len = 5
+        batch_size = 512
+        num_batches = 20000
+        sizes = [256, 128]
+        activations = ["relu", "relu"]
+        last_layer_activation = "linear"
+        reward_net = synthetic_reward.NGramSyntheticRewardNet(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            sizes=sizes,
+            activations=activations,
+            last_layer_activation=last_layer_activation,
+            context_size=3,
+        )
+        optimizer = Optimizer__Union(SGD=classes["SGD"]())
+        trainer = RewardNetTrainer(reward_net, optimizer)
+
+        weight, data_generator = create_data(
+            state_dim, action_dim, seq_len, batch_size, num_batches
+        )
+        threshold = 1
         reach_threshold = False
         for batch in data_generator():
             loss = trainer.train(batch)


### PR DESCRIPTION
Summary:
Add a n-gram MLP for synthetic reward attribution. This model uses an MLP to predict each step's reward.

Compared with single-step reward model, it uses n-gram with a context window centered around each step and zero padding.

Reviewed By: czxttkl

Differential Revision: D28362111

