### PR TITLE
Fix distributed training for pytorch lightning models

### DIFF
--- a/reagent/core/utils.py
+++ b/reagent/core/utils.py
@@ -2,6 +2,20 @@
 
 from typing import Tuple, Optional
 
+import torch
+
+
+def get_rank() -> int:
+    """
+    Returns the torch.distributed rank of the process. 0 represents
+    the main process and is the default if torch.distributed isn't set up
+    """
+    return (
+        torch.distributed.get_rank()
+        if torch.distributed.is_available() and torch.distributed.is_initialized()
+        else 0
+    )
+
 
 class lazy_property(object):
     """

--- a/reagent/reporting/reporter_base.py
+++ b/reagent/reporting/reporter_base.py
@@ -44,11 +44,9 @@ class ReporterBase(CompositeObserver):
         )
         self._reporter_observable = _ReporterObservable(self)
 
-    @rank_zero_only
     def log(self, **kwargs) -> None:
         self._reporter_observable.notify_observers(**kwargs)
 
-    @rank_zero_only
     def flush(self, epoch: int):
         logger.info(f"Epoch {epoch} ended")
 


### PR DESCRIPTION
Summary: Making these changes can finally get us distributed training for reward networks (hopefully. Still need to wait for the workflow to finish). Fix the error asked in https://fb.workplace.com/groups/pytorchLightning/permalink/455491295468768/.

Reviewed By: gji1

Differential Revision: D28318470

