### PR TITLE
Add batch norm and layer norm to synthetic reward network.

### DIFF
--- a/reagent/net_builder/synthetic_reward/ngram_synthetic_reward.py
+++ b/reagent/net_builder/synthetic_reward/ngram_synthetic_reward.py
@@ -23,6 +23,7 @@ class NGramSyntheticReward(SyntheticRewardNetBuilder):
     activations: List[str] = field(default_factory=lambda: ["relu", "relu"])
     last_layer_activation: str = "sigmoid"
     context_size: int = 3
+    use_layer_norm: bool = False
 
     def build_synthetic_reward_network(
         self,
@@ -48,6 +49,7 @@ class NGramSyntheticReward(SyntheticRewardNetBuilder):
             activations=self.activations,
             last_layer_activation=self.last_layer_activation,
             context_size=self.context_size,
+            use_layer_norm=self.use_layer_norm,
         )
         return SyntheticRewardNet(net)
 
@@ -68,6 +70,7 @@ class NGramConvNetSyntheticReward(SyntheticRewardNetBuilder):
             pool_kernel_sizes=[1, 1],
         )
     )
+    use_layer_norm: bool = False
 
     def build_synthetic_reward_network(
         self,
@@ -95,5 +98,6 @@ class NGramConvNetSyntheticReward(SyntheticRewardNetBuilder):
             last_layer_activation=self.last_layer_activation,
             context_size=self.context_size,
             conv_net_params=self.conv_net_params,
+            use_layer_norm=self.use_layer_norm,
         )
         return SyntheticRewardNet(net)

--- a/reagent/net_builder/synthetic_reward/single_step_synthetic_reward.py
+++ b/reagent/net_builder/synthetic_reward/single_step_synthetic_reward.py
@@ -20,6 +20,8 @@ class SingleStepSyntheticReward(SyntheticRewardNetBuilder):
     sizes: List[int] = field(default_factory=lambda: [256, 128])
     activations: List[str] = field(default_factory=lambda: ["relu", "relu"])
     last_layer_activation: str = "sigmoid"
+    use_batch_norm: bool = False
+    use_layer_norm: bool = False
 
     def build_synthetic_reward_network(
         self,
@@ -43,5 +45,7 @@ class SingleStepSyntheticReward(SyntheticRewardNetBuilder):
             sizes=self.sizes,
             activations=self.activations,
             last_layer_activation=self.last_layer_activation,
+            use_batch_norm=self.use_batch_norm,
+            use_layer_norm=self.use_layer_norm,
         )
         return SyntheticRewardNet(net)


### PR DESCRIPTION
Summary:
1. Add batch norm to single-step synthetic reward network;
2. Add layer norm to single-step, ngram fc and ngram conv net synthetic reward network;

The normalization helps mitigate the problem of zero predictions from the use of MSE and sigmoid output layer.

Differential Revision: D28888793

