### PR TITLE
Completely remove state from model managers

### DIFF
--- a/reagent/data/__init__.py
+++ b/reagent/data/__init__.py
@@ -1,2 +1,12 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+from .data_fetcher import DataFetcher
+from .manual_data_module import ManualDataModule
+from .reagent_data_module import ReAgentDataModule
+
+__all__ = [
+    "DataFetcher",
+    "ManualDataModule",
+    "ReAgentDataModule",
+]

--- a/reagent/data/manual_data_module.py
+++ b/reagent/data/manual_data_module.py
@@ -183,7 +183,8 @@ class ManualDataModule(ReAgentDataModule):
         self._model_manager = model_manager
 
     def get_normalization_data_map(
-        self, keys: List[str]
+        self,
+        keys: Optional[List[str]] = None,
     ) -> Dict[str, NormalizationData]:
         return self._normalization_data_map
 
@@ -192,15 +193,8 @@ class ManualDataModule(ReAgentDataModule):
         self, input_table_spec: TableSpec
     ) -> Dict[str, NormalizationData]:
         """
-        Derive preprocessing parameters from data. The keys of the dict should
-        match the keys from `required_normalization_keys()`
+        Derive preprocessing parameters from data.
         """
-        pass
-
-    @property
-    @abc.abstractmethod
-    def required_normalization_keys(self) -> List[str]:
-        """Get the normalization keys required for current instance"""
         pass
 
     def __getattr__(self, attr):

--- a/reagent/data/manual_data_module.py
+++ b/reagent/data/manual_data_module.py
@@ -222,9 +222,7 @@ class ManualDataModule(ReAgentDataModule):
                 )
             return normalization_data
 
-        raise AttributeError(
-            f"attr {attr} not available {type(self)} (subclass of ModelManager)."
-        )
+        raise AttributeError(f"attr {attr} not available {type(self)}")
 
     @property
     @abc.abstractmethod

--- a/reagent/data/manual_data_module.py
+++ b/reagent/data/manual_data_module.py
@@ -203,7 +203,7 @@ class ManualDataModule(ReAgentDataModule):
         if attr.endswith(normalization_data_suffix):
             assert self._normalization_data_map is not None, (
                 f"Trying to access {attr} but normalization_data_map "
-                "has not been set via `initialize_trainer`."
+                "has not been set. Did you run `setup()`"
             )
             normalization_key = attr[: -len(normalization_data_suffix)]
             normalization_data = self._normalization_data_map.get(

--- a/reagent/data/reagent_data_module.py
+++ b/reagent/data/reagent_data_module.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import abc
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pytorch_lightning as pl
 from reagent.core.parameters import NormalizationData
@@ -10,6 +10,7 @@ from reagent.core.parameters import NormalizationData
 class ReAgentDataModule(pl.LightningDataModule):
     @abc.abstractmethod
     def get_normalization_data_map(
-        self, keys: List[str]
+        self,
+        keys: Optional[List[str]] = None,
     ) -> Dict[str, NormalizationData]:
         pass

--- a/reagent/gym/tests/test_gym.py
+++ b/reagent/gym/tests/test_gym.py
@@ -297,7 +297,9 @@ def run_test_replay_buffer(
 
     # TODO: Also check train_reward
 
-    serving_policy = manager.create_policy(serving=True)
+    serving_policy = manager.create_policy(
+        serving=True, normalization_data_map=normalization
+    )
 
     eval_rewards = eval_policy(env, serving_policy, num_eval_episodes, serving=True)
     assert (

--- a/reagent/gym/tests/test_gym.py
+++ b/reagent/gym/tests/test_gym.py
@@ -240,12 +240,11 @@ def run_test_replay_buffer(
     logger.info(f"Normalization is: \n{pprint.pformat(normalization)}")
 
     manager = model.value
-    trainer = manager.initialize_trainer(
+    trainer = manager.build_trainer(
         use_gpu=use_gpu,
-        reward_options=RewardOptions(),
         normalization_data_map=normalization,
     )
-    training_policy = manager.create_policy(serving=False)
+    training_policy = manager.create_policy(trainer, serving=False)
 
     if not isinstance(trainer, pl.LightningModule):
         if minibatch_size is None:
@@ -298,7 +297,7 @@ def run_test_replay_buffer(
     # TODO: Also check train_reward
 
     serving_policy = manager.create_policy(
-        serving=True, normalization_data_map=normalization
+        trainer, serving=True, normalization_data_map=normalization
     )
 
     eval_rewards = eval_policy(env, serving_policy, num_eval_episodes, serving=True)
@@ -327,12 +326,11 @@ def run_test_online_episode(
     logger.info(f"Normalization is: \n{pprint.pformat(normalization)}")
 
     manager = model.value
-    trainer = manager.initialize_trainer(
+    trainer = manager.build_trainer(
         use_gpu=use_gpu,
-        reward_options=RewardOptions(),
         normalization_data_map=normalization,
     )
-    policy = manager.create_policy(serving=False)
+    policy = manager.create_policy(trainer, serving=False)
 
     device = torch.device("cuda") if use_gpu else torch.device("cpu")
 

--- a/reagent/gym/tests/test_world_model.py
+++ b/reagent/gym/tests/test_world_model.py
@@ -168,7 +168,7 @@ def train_mdnrnn_and_compute_feature_stats(
     env.seed(SEED)
 
     manager = model.value
-    trainer = manager.initialize_trainer(
+    trainer = manager.build_trainer(
         use_gpu=use_gpu,
         reward_options=RewardOptions(),
         normalization_data_map=build_normalizer(env),
@@ -292,7 +292,7 @@ def train_mdnrnn_and_train_on_embedded_env(
     env.seed(SEED)
 
     embedding_manager = embedding_model.value
-    embedding_trainer = embedding_manager.initialize_trainer(
+    embedding_trainer = embedding_manager.build_trainer(
         use_gpu=use_gpu,
         reward_options=RewardOptions(),
         normalization_data_map=build_normalizer(env),
@@ -340,7 +340,7 @@ def train_mdnrnn_and_train_on_embedded_env(
         state_max_value=state_max,
     )
     agent_manager = train_model.value
-    agent_trainer = agent_manager.initialize_trainer(
+    agent_trainer = agent_manager.build_trainer(
         use_gpu=use_gpu,
         reward_options=RewardOptions(),
         # pyre-fixme[6]: Expected `EnvWrapper` for 1st param but got
@@ -365,7 +365,7 @@ def train_mdnrnn_and_train_on_embedded_env(
 
     # evaluate model
     rewards = []
-    policy = agent_manager.create_policy(serving=False)
+    policy = agent_manager.create_policy(agent_trainer, serving=False)
     # pyre-fixme[6]: Expected `EnvWrapper` for 1st param but got
     #  `StateEmbedEnvironment`.
     agent = Agent.create_for_env(embed_env, policy=policy, device=device)

--- a/reagent/model_managers/actor_critic/sac.py
+++ b/reagent/model_managers/actor_critic/sac.py
@@ -23,6 +23,7 @@ from reagent.net_builder.value.fully_connected import (
     FullyConnected as ValueFullyConnected,
 )
 from reagent.training import SACTrainer, SACTrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,10 @@ class SAC(ActorCriticBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> SACTrainer:
         actor_net_builder = self.actor_net_builder.value
         # pyre-fixme[16]: `SAC` has no attribute `_actor_network`.

--- a/reagent/model_managers/actor_critic/sac.py
+++ b/reagent/model_managers/actor_critic/sac.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import param_hash
+from reagent.core.parameters import NormalizationData, NormalizationKey, param_hash
 from reagent.model_managers.actor_critic_base import ActorCriticBase
 from reagent.models.base import ModelBase
 from reagent.net_builder.continuous_actor.gaussian_fully_connected import (
@@ -111,12 +111,15 @@ class SAC(ActorCriticBase):
     def get_reporter(self):
         return None
 
-    def build_serving_module(self) -> Dict[str, torch.nn.Module]:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         assert self._actor_network is not None
         actor_serving_module = self.actor_net_builder.value.build_serving_module(
             self._actor_network,
-            self.state_normalization_data,
-            self.action_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
             serve_mean_policy=self.serve_mean_policy,
         )
         return actor_serving_module

--- a/reagent/model_managers/actor_critic/sac.py
+++ b/reagent/model_managers/actor_critic/sac.py
@@ -66,23 +66,28 @@ class SAC(ActorCriticBase):
     #  inconsistently.
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> SACTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> SACTrainer:
         actor_net_builder = self.actor_net_builder.value
         # pyre-fixme[16]: `SAC` has no attribute `_actor_network`.
         # pyre-fixme[16]: `SAC` has no attribute `_actor_network`.
         self._actor_network = actor_net_builder.build_actor(
-            self.state_normalization_data, self.action_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )
 
         critic_net_builder = self.critic_net_builder.value
         # pyre-fixme[16]: `SAC` has no attribute `_q1_network`.
         # pyre-fixme[16]: `SAC` has no attribute `_q1_network`.
         self._q1_network = critic_net_builder.build_q_network(
-            self.state_normalization_data, self.action_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )
         q2_network = (
             critic_net_builder.build_q_network(
-                self.state_normalization_data, self.action_normalization_data
+                normalization_data_map[NormalizationKey.STATE],
+                normalization_data_map[NormalizationKey.ACTION],
             )
             if self.use_2_q_functions
             else None
@@ -94,7 +99,7 @@ class SAC(ActorCriticBase):
             # pyre-fixme[16]: `Optional` has no attribute `value`.
             value_net_builder = self.value_net_builder.value
             value_network = value_net_builder.build_value_network(
-                self.state_normalization_data
+                normalization_data_map[NormalizationKey.STATE]
             )
 
         trainer = SACTrainer(

--- a/reagent/model_managers/actor_critic/td3.py
+++ b/reagent/model_managers/actor_critic/td3.py
@@ -27,6 +27,7 @@ from reagent.net_builder.unions import (
 )
 from reagent.reporting.td3_reporter import TD3Reporter
 from reagent.training import TD3Trainer, TD3TrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,10 @@ class TD3(ActorCriticBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> TD3Trainer:
         actor_net_builder = self.actor_net_builder.value
         # pyre-fixme[16]: `TD3` has no attribute `_actor_network`.

--- a/reagent/model_managers/actor_critic/td3.py
+++ b/reagent/model_managers/actor_critic/td3.py
@@ -3,11 +3,16 @@
 
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import EvaluationParameters, param_hash
+from reagent.core.parameters import (
+    EvaluationParameters,
+    NormalizationData,
+    NormalizationKey,
+    param_hash,
+)
 from reagent.model_managers.actor_critic_base import ActorCriticBase
 from reagent.models.base import ModelBase
 from reagent.net_builder.continuous_actor.fully_connected import (
@@ -92,11 +97,14 @@ class TD3(ActorCriticBase):
     def get_reporter(self):
         return TD3Reporter()
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         net_builder = self.actor_net_builder.value
         assert self._actor_network is not None
         return net_builder.build_serving_module(
             self._actor_network,
-            self.state_normalization_data,
-            self.action_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )

--- a/reagent/model_managers/actor_critic/td3.py
+++ b/reagent/model_managers/actor_critic/td3.py
@@ -26,6 +26,7 @@ from reagent.net_builder.unions import (
     ParametricDQNNetBuilder__Union,
 )
 from reagent.reporting.td3_reporter import TD3Reporter
+from reagent.training import ReAgentLightningModule
 from reagent.training import TD3Trainer, TD3TrainerParameters
 from reagent.workflow.types import RewardOptions
 
@@ -58,11 +59,8 @@ class TD3(ActorCriticBase):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self._actor_network: Optional[ModelBase] = None
         self.rl_parameters = self.trainer_param.rl
 
-    # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
-    #  inconsistently.
     def build_trainer(
         self,
         normalization_data_map: Dict[str, NormalizationData],
@@ -70,17 +68,13 @@ class TD3(ActorCriticBase):
         reward_options: Optional[RewardOptions] = None,
     ) -> TD3Trainer:
         actor_net_builder = self.actor_net_builder.value
-        # pyre-fixme[16]: `TD3` has no attribute `_actor_network`.
-        # pyre-fixme[16]: `TD3` has no attribute `_actor_network`.
-        self._actor_network = actor_net_builder.build_actor(
+        actor_network = actor_net_builder.build_actor(
             normalization_data_map[NormalizationKey.STATE],
             normalization_data_map[NormalizationKey.ACTION],
         )
 
         critic_net_builder = self.critic_net_builder.value
-        # pyre-fixme[16]: `TD3` has no attribute `_q1_network`.
-        # pyre-fixme[16]: `TD3` has no attribute `_q1_network`.
-        self._q1_network = critic_net_builder.build_q_network(
+        q1_network = critic_net_builder.build_q_network(
             normalization_data_map[NormalizationKey.STATE],
             normalization_data_map[NormalizationKey.ACTION],
         )
@@ -94,8 +88,8 @@ class TD3(ActorCriticBase):
         )
 
         trainer = TD3Trainer(
-            actor_network=self._actor_network,
-            q1_network=self._q1_network,
+            actor_network=actor_network,
+            q1_network=q1_network,
             q2_network=q2_network,
             # pyre-fixme[16]: `TD3TrainerParameters` has no attribute `asdict`.
             # pyre-fixme[16]: `TD3TrainerParameters` has no attribute `asdict`.
@@ -108,12 +102,13 @@ class TD3(ActorCriticBase):
 
     def build_serving_module(
         self,
+        trainer_module: ReAgentLightningModule,
         normalization_data_map: Dict[str, NormalizationData],
     ) -> torch.nn.Module:
+        assert isinstance(trainer_module, TD3Trainer)
         net_builder = self.actor_net_builder.value
-        assert self._actor_network is not None
         return net_builder.build_serving_module(
-            self._actor_network,
+            trainer_module.actor_network,
             normalization_data_map[NormalizationKey.STATE],
             normalization_data_map[NormalizationKey.ACTION],
         )

--- a/reagent/model_managers/actor_critic/td3.py
+++ b/reagent/model_managers/actor_critic/td3.py
@@ -62,23 +62,28 @@ class TD3(ActorCriticBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> TD3Trainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> TD3Trainer:
         actor_net_builder = self.actor_net_builder.value
         # pyre-fixme[16]: `TD3` has no attribute `_actor_network`.
         # pyre-fixme[16]: `TD3` has no attribute `_actor_network`.
         self._actor_network = actor_net_builder.build_actor(
-            self.state_normalization_data, self.action_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )
 
         critic_net_builder = self.critic_net_builder.value
         # pyre-fixme[16]: `TD3` has no attribute `_q1_network`.
         # pyre-fixme[16]: `TD3` has no attribute `_q1_network`.
         self._q1_network = critic_net_builder.build_q_network(
-            self.state_normalization_data, self.action_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )
         q2_network = (
             critic_net_builder.build_q_network(
-                self.state_normalization_data, self.action_normalization_data
+                normalization_data_map[NormalizationKey.STATE],
+                normalization_data_map[NormalizationKey.ACTION],
             )
             if self.use_2_q_functions
             else None

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -101,10 +101,6 @@ class ActorCriticBase(ModelManager):
         self._actor_network: Optional[ModelBase] = None
         self._q1_network: Optional[ModelBase] = None
 
-    @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise NotImplementedError
-
     def create_policy(self, serving: bool) -> Policy:
         """Create online actor critic policy."""
 

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -101,11 +101,18 @@ class ActorCriticBase(ModelManager):
         self._actor_network: Optional[ModelBase] = None
         self._q1_network: Optional[ModelBase] = None
 
-    def create_policy(self, serving: bool) -> Policy:
+    def create_policy(
+        self,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ) -> Policy:
         """Create online actor critic policy."""
 
         if serving:
-            return create_predictor_policy_from_model(self.build_serving_module())
+            assert normalization_data_map
+            return create_predictor_policy_from_model(
+                self.build_serving_module(normalization_data_map)
+            )
         else:
             return ActorPolicyWrapper(self._actor_network)
 

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -17,7 +17,6 @@ from reagent.data import DataFetcher, ReAgentDataModule, ManualDataModule
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.model_managers.model_manager import ModelManager
-from reagent.models.base import ModelBase
 from reagent.preprocessing.batch_preprocessor import (
     BatchPreprocessor,
     PolicyNetworkBatchPreprocessor,
@@ -26,6 +25,7 @@ from reagent.preprocessing.batch_preprocessor import (
 from reagent.preprocessing.normalization import get_feature_config
 from reagent.preprocessing.types import InputColumn
 from reagent.reporting.actor_critic_reporter import ActorCriticReporter
+from reagent.training import ReAgentLightningModule
 from reagent.workflow.identify_types_flow import identify_normalization_parameters
 from reagent.workflow.types import (
     Dataset,
@@ -34,10 +34,8 @@ from reagent.workflow.types import (
     ResourceOptions,
     RewardOptions,
     RLTrainingOutput,
-    RLTrainingReport,
     TableSpec,
 )
-from reagent.workflow.utils import train_eval_lightning
 
 
 logger = logging.getLogger(__name__)
@@ -93,15 +91,9 @@ class ActorCriticBase(ModelManager):
         self._state_preprocessing_options = self.state_preprocessing_options
         self._action_preprocessing_options = self.action_preprocessing_options
 
-        # To be filled by property metrics_to_score
-        self._metrics_to_score: Optional[List[str]] = None
-
-        # To be filled by subclasses
-        self._actor_network: Optional[ModelBase] = None
-        self._q1_network: Optional[ModelBase] = None
-
     def create_policy(
         self,
+        trainer_module: ReAgentLightningModule,
         serving: bool = False,
         normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
     ) -> Policy:
@@ -110,10 +102,10 @@ class ActorCriticBase(ModelManager):
         if serving:
             assert normalization_data_map
             return create_predictor_policy_from_model(
-                self.build_serving_module(normalization_data_map)
+                self.build_serving_module(trainer_module, normalization_data_map)
             )
         else:
-            return ActorPolicyWrapper(self._actor_network)
+            return ActorPolicyWrapper(trainer_module.actor_network)
 
     @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
@@ -181,51 +173,6 @@ class ActorCriticBase(ModelManager):
 
     def get_reporter(self):
         return ActorCriticReporter()
-
-    # TODO: deprecate, once we deprecate internal page handlers
-    def train(
-        self,
-        train_dataset: Optional[Dataset],
-        eval_dataset: Optional[Dataset],
-        test_dataset: Optional[Dataset],
-        data_module: Optional[ReAgentDataModule],
-        num_epochs: int,
-        reader_options: ReaderOptions,
-        resource_options: ResourceOptions,
-    ) -> RLTrainingOutput:
-        reporter = self.get_reporter()
-        # pyre-fixme[16]: `Trainer` has no attribute `set_reporter`.
-        # pyre-fixme[16]: `Trainer` has no attribute `set_reporter`.
-        self.trainer.set_reporter(reporter)
-        assert data_module
-
-        # assert eval_dataset is None
-
-        # pyre-fixme[16]: `ActorCriticBase` has no attribute `_lightning_trainer`.
-        self._lightning_trainer = train_eval_lightning(
-            train_dataset=train_dataset,
-            eval_dataset=eval_dataset,
-            test_dataset=test_dataset,
-            trainer_module=self.trainer,
-            data_module=data_module,
-            num_epochs=num_epochs,
-            logger_name="ActorCritic",
-            reader_options=reader_options,
-            checkpoint_path=self._lightning_checkpoint_path,
-            resource_options=resource_options or ResourceOptions(),
-        )
-        if reporter is None:
-            training_report = None
-        else:
-            # pyre-fixme[16]: `RLTrainingReport` has no attribute `make_union_instance`.
-            training_report = RLTrainingReport.make_union_instance(
-                reporter.generate_training_report()
-            )
-        logger_data = self._lightning_trainer.logger.line_plot_aggregated
-        self._lightning_trainer.logger.clear_local_data()
-        return RLTrainingOutput(
-            training_report=training_report, logger_data=logger_data
-        )
 
 
 class ActorCriticDataModule(ManualDataModule):

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -14,7 +14,6 @@ from reagent.core.parameters import (
     NormalizationKey,
 )
 from reagent.data import DataFetcher, ReAgentDataModule, ManualDataModule
-from reagent.evaluation.evaluator import get_metrics_to_score
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.model_managers.model_manager import ModelManager
@@ -115,17 +114,6 @@ class ActorCriticBase(ModelManager):
             )
         else:
             return ActorPolicyWrapper(self._actor_network)
-
-    @property
-    def metrics_to_score(self) -> List[str]:
-        assert self._reward_options is not None
-        if self._metrics_to_score is None:
-            # pyre-fixme[16]: `ActorCriticBase` has no attribute `_metrics_to_score`.
-            # pyre-fixme[16]: `ActorCriticBase` has no attribute `_metrics_to_score`.
-            self._metrics_to_score = get_metrics_to_score(
-                self._reward_options.metric_reward_values
-            )
-        return self._metrics_to_score
 
     @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -168,11 +168,6 @@ class ActorCriticBase(ModelManager):
         )
         return action_preprocessing_options
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise NotImplementedError
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -177,9 +177,6 @@ class ActorCriticBase(ModelManager):
     ) -> Dataset:
         raise NotImplementedError
 
-    def build_batch_preprocessor(self, use_gpu: bool) -> BatchPreprocessor:
-        raise NotImplementedError
-
     def get_data_module(
         self,
         *,

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -168,15 +168,6 @@ class ActorCriticBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise NotImplementedError
-
     def get_data_module(
         self,
         *,

--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -171,10 +171,6 @@ class ActorCriticBase(ModelManager):
         )
         return action_preprocessing_options
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
-
     def get_data_module(
         self,
         *,
@@ -249,8 +245,7 @@ class ActorCriticDataModule(ManualDataModule):
         self, input_table_spec: TableSpec
     ) -> Dict[str, NormalizationData]:
         """
-        Derive preprocessing parameters from data. The keys of the dict should
-        match the keys from `required_normalization_keys()`
+        Derive preprocessing parameters from data.
         """
         # Run state feature identification
         state_normalization_parameters = identify_normalization_parameters(
@@ -274,11 +269,6 @@ class ActorCriticDataModule(ManualDataModule):
                 dense_normalization_parameters=action_normalization_parameters
             ),
         }
-
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        """Get the normalization keys required for current instance"""
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
     @property
     def should_generate_eval_dataset(self) -> bool:

--- a/reagent/model_managers/discrete/discrete_c51dqn.py
+++ b/reagent/model_managers/discrete/discrete_c51dqn.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Dict
+from typing import Optional
 
 import torch
 from reagent.core.dataclasses import dataclass, field
@@ -10,6 +11,7 @@ from reagent.model_managers.discrete_dqn_base import DiscreteDQNBase
 from reagent.net_builder.categorical_dqn.categorical import Categorical
 from reagent.net_builder.unions import CategoricalDQNNetBuilder__Union
 from reagent.training import C51Trainer, C51TrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -37,17 +39,26 @@ class DiscreteC51DQN(DiscreteDQNBase):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self.rl_parameters = self.trainer_param.rl
-        self.action_names = self.trainer_param.actions
         assert len(self.action_names) > 1, "DiscreteC51DQN needs at least 2 actions"
         assert (
             self.trainer_param.minibatch_size % 8 == 0
         ), "The minibatch size must be divisible by 8 for performance reasons."
 
+    @property
+    def action_names(self):
+        return self.trainer_param.actions
+
+    @property
+    def rl_parameters(self):
+        return self.trainer_param.rl
+
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> C51Trainer:
         net_builder = self.net_builder.value
         q_network = net_builder.build_q_network(

--- a/reagent/model_managers/discrete/discrete_c51dqn.py
+++ b/reagent/model_managers/discrete/discrete_c51dqn.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import logging
+from typing import Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import param_hash
+from reagent.core.parameters import param_hash, NormalizationData, NormalizationKey
 from reagent.model_managers.discrete_dqn_base import DiscreteDQNBase
 from reagent.net_builder.categorical_dqn.categorical import Categorical
 from reagent.net_builder.unions import CategoricalDQNNetBuilder__Union
@@ -75,7 +76,10 @@ class DiscreteC51DQN(DiscreteDQNBase):
             **self.trainer_param.asdict(),
         )
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         """
         Returns a TorchScript predictor module
         """
@@ -83,7 +87,7 @@ class DiscreteC51DQN(DiscreteDQNBase):
         net_builder = self.net_builder.value
         return net_builder.build_serving_module(
             self._q_network,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             action_names=self.action_names,
             state_feature_config=self.state_feature_config,
         )

--- a/reagent/model_managers/discrete/discrete_c51dqn.py
+++ b/reagent/model_managers/discrete/discrete_c51dqn.py
@@ -46,10 +46,12 @@ class DiscreteC51DQN(DiscreteDQNBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> C51Trainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> C51Trainer:
         net_builder = self.net_builder.value
         q_network = net_builder.build_q_network(
-            state_normalization_data=self.state_normalization_data,
+            state_normalization_data=normalization_data_map[NormalizationKey.STATE],
             output_dim=len(self.action_names),
             # pyre-fixme[16]: `C51TrainerParameters` has no attribute `num_atoms`.
             # pyre-fixme[16]: `C51TrainerParameters` has no attribute `num_atoms`.

--- a/reagent/model_managers/discrete/discrete_crr.py
+++ b/reagent/model_managers/discrete/discrete_crr.py
@@ -95,11 +95,13 @@ class DiscreteCRR(DiscreteDQNBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> DiscreteCRRTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> DiscreteCRRTrainer:
         actor_net_builder = self.actor_net_builder.value
         # pyre-fixme[16]: `DiscreteCRR` has no attribute `_actor_network`.
         self._actor_network = actor_net_builder.build_actor(
-            self.state_normalization_data, len(self.action_names)
+            normalization_data_map[NormalizationKey.STATE], len(self.action_names)
         )
 
         # The arguments to q_network1 and q_network2 below are modeled after those in discrete_dqn.py
@@ -109,14 +111,14 @@ class DiscreteCRR(DiscreteDQNBase):
         # pyre-fixme[16]: `DiscreteCRR` has no attribute `_q1_network`.
         self._q1_network = critic_net_builder.build_q_network(
             self.state_feature_config,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
         )
 
         q2_network = (
             critic_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 len(self.action_names),
             )
             # pyre-fixme[16]: `CRRTrainerParameters` has no attribute
@@ -136,12 +138,12 @@ class DiscreteCRR(DiscreteDQNBase):
             cpe_net_builder = self.cpe_net_builder.value
             reward_network = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
             q_network_cpe = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
 

--- a/reagent/model_managers/discrete/discrete_dqn.py
+++ b/reagent/model_managers/discrete/discrete_dqn.py
@@ -48,11 +48,13 @@ class DiscreteDQN(DiscreteDQNBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> DQNTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> DQNTrainer:
         net_builder = self.net_builder.value
         q_network = net_builder.build_q_network(
             self.state_feature_config,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
         )
 
@@ -69,12 +71,12 @@ class DiscreteDQN(DiscreteDQNBase):
             cpe_net_builder = self.cpe_net_builder.value
             reward_network = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
             q_network_cpe = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
 

--- a/reagent/model_managers/discrete/discrete_qrdqn.py
+++ b/reagent/model_managers/discrete/discrete_qrdqn.py
@@ -50,10 +50,12 @@ class DiscreteQRDQN(DiscreteDQNBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> QRDQNTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> QRDQNTrainer:
         net_builder = self.net_builder.value
         q_network = net_builder.build_q_network(
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
             # pyre-fixme[16]: `QRDQNTrainerParameters` has no attribute `num_atoms`.
             num_atoms=self.trainer_param.num_atoms,
@@ -72,12 +74,12 @@ class DiscreteQRDQN(DiscreteDQNBase):
             cpe_net_builder = self.cpe_net_builder.value
             reward_network = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
             q_network_cpe = cpe_net_builder.build_q_network(
                 self.state_feature_config,
-                self.state_normalization_data,
+                normalization_data_map[NormalizationKey.STATE],
                 num_output_nodes,
             )
 

--- a/reagent/model_managers/discrete/discrete_qrdqn.py
+++ b/reagent/model_managers/discrete/discrete_qrdqn.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import logging
+from typing import Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import param_hash
+from reagent.core.parameters import NormalizationData, NormalizationKey, param_hash
 from reagent.model_managers.discrete_dqn_base import DiscreteDQNBase
 from reagent.net_builder.discrete_dqn.fully_connected import FullyConnected
 from reagent.net_builder.quantile_dqn.dueling_quantile import DuelingQuantile
@@ -97,7 +98,10 @@ class DiscreteQRDQN(DiscreteDQNBase):
         )
         return trainer
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         """
         Returns a TorchScript predictor module
         """
@@ -105,7 +109,7 @@ class DiscreteQRDQN(DiscreteDQNBase):
         net_builder = self.net_builder.value
         return net_builder.build_serving_module(
             self._q_network,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             action_names=self.action_names,
             state_feature_config=self.state_feature_config,
         )

--- a/reagent/model_managers/discrete/discrete_qrdqn.py
+++ b/reagent/model_managers/discrete/discrete_qrdqn.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import NormalizationData, NormalizationKey, param_hash
+from reagent.evaluation.evaluator import get_metrics_to_score
 from reagent.model_managers.discrete_dqn_base import DiscreteDQNBase
 from reagent.net_builder.discrete_dqn.fully_connected import FullyConnected
 from reagent.net_builder.quantile_dqn.dueling_quantile import DuelingQuantile
@@ -14,6 +15,7 @@ from reagent.net_builder.unions import (
     QRDQNNetBuilder__Union,
 )
 from reagent.training import QRDQNTrainer, QRDQNTrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -41,17 +43,26 @@ class DiscreteQRDQN(DiscreteDQNBase):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self.rl_parameters = self.trainer_param.rl
-        self.action_names = self.trainer_param.actions
         assert len(self.action_names) > 1, "DiscreteQRDQNModel needs at least 2 actions"
         assert (
             self.trainer_param.minibatch_size % 8 == 0
         ), "The minibatch size must be divisible by 8 for performance reasons."
 
+    @property
+    def action_names(self):
+        return self.trainer_param.actions
+
+    @property
+    def rl_parameters(self):
+        return self.trainer_param.rl
+
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> QRDQNTrainer:
         net_builder = self.net_builder.value
         q_network = net_builder.build_q_network(
@@ -63,10 +74,13 @@ class DiscreteQRDQN(DiscreteDQNBase):
 
         q_network_target = q_network.get_target_network()
 
+        reward_options = reward_options or RewardOptions()
+        metrics_to_score = get_metrics_to_score(reward_options.metric_reward_values)
+
         reward_network, q_network_cpe, q_network_cpe_target = None, None, None
         if self.eval_parameters.calc_cpe_in_training:
             # Metrics + reward
-            num_output_nodes = (len(self.metrics_to_score) + 1) * len(
+            num_output_nodes = (len(metrics_to_score) + 1) * len(
                 # pyre-fixme[16]: `QRDQNTrainerParameters` has no attribute `actions`.
                 self.trainer_param.actions
             )
@@ -93,7 +107,7 @@ class DiscreteQRDQN(DiscreteDQNBase):
             reward_network=reward_network,
             q_network_cpe=q_network_cpe,
             q_network_cpe_target=q_network_cpe_target,
-            metrics_to_score=self.metrics_to_score,
+            metrics_to_score=metrics_to_score,
             evaluation=self.eval_parameters,
             # pyre-fixme[16]: `QRDQNTrainerParameters` has no attribute `asdict`.
             **self.trainer_param.asdict(),

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -65,11 +65,17 @@ class DiscreteDQNBase(ModelManager):
         self._metrics_to_score = None
         self._q_network: Optional[ModelBase] = None
 
-    def create_policy(self, serving: bool) -> Policy:
+    def create_policy(
+        self,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ) -> Policy:
         """Create an online DiscreteDQN Policy from env."""
         if serving:
+            assert normalization_data_map
             return create_predictor_policy_from_model(
-                self.build_serving_module(), rl_parameters=self.rl_parameters
+                self.build_serving_module(normalization_data_map),
+                rl_parameters=self.rl_parameters,
             )
         else:
             sampler = GreedyActionSampler()

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -92,10 +92,6 @@ class DiscreteDQNBase(ModelManager):
         return self._metrics_to_score
 
     @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise RuntimeError
-
-    @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -99,11 +99,6 @@ class DiscreteDQNBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise RuntimeError
-
     def query_data(
         self,
         input_table_spec: TableSpec,

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -29,6 +29,7 @@ from reagent.preprocessing.batch_preprocessor import (
 from reagent.preprocessing.preprocessor import Preprocessor
 from reagent.preprocessing.types import InputColumn
 from reagent.reporting.discrete_dqn_reporter import DiscreteDQNReporter
+from reagent.training import ReAgentLightningModule
 from reagent.workflow.identify_types_flow import identify_normalization_parameters
 from reagent.workflow.types import (
     Dataset,
@@ -61,10 +62,10 @@ class DiscreteDQNBase(ModelManager):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self._q_network: Optional[ModelBase] = None
 
     def create_policy(
         self,
+        trainer_module: ReAgentLightningModule,
         serving: bool = False,
         normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
     ) -> Policy:
@@ -72,12 +73,12 @@ class DiscreteDQNBase(ModelManager):
         if serving:
             assert normalization_data_map
             return create_predictor_policy_from_model(
-                self.build_serving_module(normalization_data_map),
+                self.build_serving_module(trainer_module, normalization_data_map),
                 rl_parameters=self.rl_parameters,
             )
         else:
             sampler = GreedyActionSampler()
-            scorer = discrete_dqn_scorer(self._q_network)
+            scorer = discrete_dqn_scorer(trainer_module.q_network)
             return Policy(scorer=scorer, sampler=sampler)
 
     @property
@@ -113,55 +114,6 @@ class DiscreteDQNBase(ModelManager):
             self.trainer_param.actions,
             target_action_distribution=self.target_action_distribution,
         )
-
-    def train(
-        self,
-        train_dataset: Optional[Dataset],
-        eval_dataset: Optional[Dataset],
-        test_dataset: Optional[Dataset],
-        data_module: Optional[ReAgentDataModule],
-        num_epochs: int,
-        reader_options: ReaderOptions,
-        resource_options: Optional[ResourceOptions] = None,
-    ) -> RLTrainingOutput:
-        """
-        Train the model
-
-        Returns partially filled RLTrainingOutput.
-        The field that should not be filled are:
-        - output_path
-        """
-        reporter = self.get_reporter()
-        # pyre-fixme[16]: `RLTrainer` has no attribute `set_reporter`.
-        self.trainer.set_reporter(reporter)
-        assert data_module
-
-        # pyre-fixme[16]: `DiscreteDQNBase` has no attribute `_lightning_trainer`.
-        self._lightning_trainer = train_eval_lightning(
-            train_dataset=train_dataset,
-            eval_dataset=eval_dataset,
-            test_dataset=test_dataset,
-            trainer_module=self.trainer,
-            data_module=data_module,
-            num_epochs=num_epochs,
-            logger_name="DiscreteDqn",
-            reader_options=reader_options,
-            checkpoint_path=self._lightning_checkpoint_path,
-            resource_options=resource_options,
-        )
-        rank = get_rank()
-        if rank == 0:
-            # pyre-fixme[16]: `RLTrainingReport` has no attribute `make_union_instance`.
-            training_report = RLTrainingReport.make_union_instance(
-                reporter.generate_training_report()
-            )
-            logger_data = self._lightning_trainer.logger.line_plot_aggregated
-            self._lightning_trainer.logger.clear_local_data()
-            return RLTrainingOutput(
-                training_report=training_report, logger_data=logger_data
-            )
-        # Output from processes with non-0 rank is not used
-        return RLTrainingOutput()
 
 
 class DiscreteDqnDataModule(ManualDataModule):

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -108,9 +108,6 @@ class DiscreteDQNBase(ModelManager):
     def multi_steps(self) -> Optional[int]:
         return self.rl_parameters.multi_steps
 
-    def build_batch_preprocessor(self, use_gpu: bool) -> BatchPreprocessor:
-        raise RuntimeError
-
     def get_data_module(
         self,
         *,

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -73,8 +73,7 @@ class DiscreteDQNBase(ModelManager):
             )
         else:
             sampler = GreedyActionSampler()
-            # pyre-fixme[16]: `RLTrainer` has no attribute `q_network`.
-            scorer = discrete_dqn_scorer(self.trainer.q_network)
+            scorer = discrete_dqn_scorer(self._q_network)
             return Policy(scorer=scorer, sampler=sampler)
 
     @property

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -95,15 +95,6 @@ class DiscreteDQNBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise RuntimeError
-
     @property
     def multi_steps(self) -> Optional[int]:
         return self.rl_parameters.multi_steps

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -13,7 +13,6 @@ from reagent.core.parameters import (
 from reagent.data.data_fetcher import DataFetcher
 from reagent.data.manual_data_module import ManualDataModule
 from reagent.data.reagent_data_module import ReAgentDataModule
-from reagent.evaluation.evaluator import get_metrics_to_score
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.gym.policies.samplers.discrete_sampler import (
@@ -62,7 +61,6 @@ class DiscreteDQNBase(ModelManager):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self._metrics_to_score = None
         self._q_network: Optional[ModelBase] = None
 
     def create_policy(
@@ -85,16 +83,6 @@ class DiscreteDQNBase(ModelManager):
     @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
         return self.state_feature_config_provider.value.get_model_feature_config()
-
-    @property
-    def metrics_to_score(self) -> List[str]:
-        assert self._reward_options is not None
-        if self._metrics_to_score is None:
-            # pyre-fixme[16]: `DiscreteDQNBase` has no attribute `_metrics_to_score`.
-            self._metrics_to_score = get_metrics_to_score(
-                self._reward_options.metric_reward_values
-            )
-        return self._metrics_to_score
 
     @property
     def multi_steps(self) -> Optional[int]:

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -97,10 +97,6 @@ class DiscreteDQNBase(ModelManager):
         return self._metrics_to_score
 
     @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE]
-
-    @property
     def multi_steps(self) -> Optional[int]:
         return self.rl_parameters.multi_steps
 
@@ -184,10 +180,6 @@ class DiscreteDqnDataModule(ManualDataModule):
     @property
     def should_generate_eval_dataset(self) -> bool:
         return self.model_manager.eval_parameters.calc_cpe_in_training
-
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE]
 
     def run_feature_identification(
         self, input_table_spec: TableSpec

--- a/reagent/model_managers/model_based/cross_entropy_method.py
+++ b/reagent/model_managers/model_based/cross_entropy_method.py
@@ -20,6 +20,7 @@ from reagent.models.cem_planner import CEMPlannerNetwork
 from reagent.preprocessing.identify_types import CONTINUOUS_ACTION
 from reagent.preprocessing.normalization import get_num_output_features
 from reagent.training.cem_trainer import CEMTrainer
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,10 @@ class CrossEntropyMethod(WorldModelBase):
         return CEMPolicy(self.cem_planner_network, self.discrete_action)
 
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> CEMTrainer:
         world_model_manager: WorldModel = WorldModel(
             trainer_param=self.trainer_param.mdnrnn
@@ -75,7 +79,9 @@ class CrossEntropyMethod(WorldModelBase):
             normalization_data_map,
         )
         world_model_trainers = [
-            world_model_manager.build_trainer(normalization_data_map, use_gpu)
+            world_model_manager.build_trainer(
+                normalization_data_map, reward_options=reward_options, use_gpu=use_gpu
+            )
             for _ in range(self.trainer_param.num_world_models)
         ]
         world_model_nets = [trainer.memory_network for trainer in world_model_trainers]

--- a/reagent/model_managers/model_based/cross_entropy_method.py
+++ b/reagent/model_managers/model_based/cross_entropy_method.py
@@ -19,6 +19,7 @@ from reagent.model_managers.world_model_base import WorldModelBase
 from reagent.models.cem_planner import CEMPlannerNetwork
 from reagent.preprocessing.identify_types import CONTINUOUS_ACTION
 from reagent.preprocessing.normalization import get_num_output_features
+from reagent.training import ReAgentLightningModule
 from reagent.training.cem_trainer import CEMTrainer
 from reagent.workflow.types import RewardOptions
 
@@ -59,6 +60,7 @@ class CrossEntropyMethod(WorldModelBase):
     # TODO: should this be in base class?
     def create_policy(
         self,
+        trainer_module: ReAgentLightningModule,
         serving: bool = False,
         normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
     ) -> Policy:
@@ -73,10 +75,10 @@ class CrossEntropyMethod(WorldModelBase):
         world_model_manager: WorldModel = WorldModel(
             trainer_param=self.trainer_param.mdnrnn
         )
-        world_model_manager.initialize_trainer(
-            use_gpu,
-            self.reward_options,
-            normalization_data_map,
+        world_model_manager.build_trainer(
+            use_gpu=use_gpu,
+            reward_options=reward_options,
+            normalization_data_map=normalization_data_map,
         )
         world_model_trainers = [
             world_model_manager.build_trainer(

--- a/reagent/model_managers/model_based/cross_entropy_method.py
+++ b/reagent/model_managers/model_based/cross_entropy_method.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 import numpy as np
 import reagent.core.types as rlt
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import CEMTrainerParameters, param_hash
+from reagent.core.parameters import CEMTrainerParameters, param_hash, NormalizationData
 from reagent.gym.policies.policy import Policy
 from reagent.model_managers.model_based.world_model import WorldModel
 from reagent.model_managers.world_model_base import WorldModelBase
@@ -51,7 +51,11 @@ class CrossEntropyMethod(WorldModelBase):
         super().__post_init_post_parse__()
 
     # TODO: should this be in base class?
-    def create_policy(self, serving: bool = False) -> Policy:
+    def create_policy(
+        self,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ) -> Policy:
         return CEMPolicy(self.cem_planner_network, self.discrete_action)
 
     def build_trainer(self, use_gpu: bool) -> CEMTrainer:
@@ -121,9 +125,3 @@ class CrossEntropyMethod(WorldModelBase):
             parameters=self.trainer_param,
             use_gpu=use_gpu,
         )
-
-    def build_serving_module(self) -> torch.nn.Module:
-        """
-        Returns a TorchScript predictor module
-        """
-        raise NotImplementedError()

--- a/reagent/model_managers/model_based/seq2reward_model.py
+++ b/reagent/model_managers/model_based/seq2reward_model.py
@@ -44,12 +44,15 @@ class Seq2RewardModel(WorldModelBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(self, use_gpu: bool) -> Seq2RewardTrainer:
-        seq2reward_network = self.net_builder.value.build_value_network(
-            self.state_normalization_data
-        )
+        # pyre-fixme[16]: `Seq2RewardModel` has no attribute `_seq2reward_network`.
+        self._seq2reward_network = (
+            seq2reward_network
+        ) = self.net_builder.value.build_value_network(self.state_normalization_data)
         trainer = Seq2RewardTrainer(
             seq2reward_network=seq2reward_network, params=self.trainer_param
         )
+        # pyre-fixme[16]: `Seq2RewardModel` has no attribute `_step_predict_network`.
+        self._step_predict_network = trainer.step_predict_network
         return trainer
 
     def get_reporter(self) -> Seq2RewardReporter:

--- a/reagent/model_managers/model_based/seq2reward_model.py
+++ b/reagent/model_managers/model_based/seq2reward_model.py
@@ -57,9 +57,3 @@ class Seq2RewardModel(WorldModelBase):
 
     def get_reporter(self) -> Seq2RewardReporter:
         return Seq2RewardReporter(self.trainer_param.action_names)
-
-    def build_serving_module(self) -> torch.nn.Module:
-        """
-        Returns a TorchScript predictor module
-        """
-        raise NotImplementedError()

--- a/reagent/model_managers/model_based/seq2reward_model.py
+++ b/reagent/model_managers/model_based/seq2reward_model.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Optional, Dict
 
-import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import (
     Seq2RewardTrainerParameters,
@@ -17,7 +16,7 @@ from reagent.net_builder.value.fully_connected import FullyConnected
 from reagent.net_builder.value.seq2reward_rnn import Seq2RewardNetBuilder
 from reagent.reporting.seq2reward_reporter import Seq2RewardReporter
 from reagent.training.world_model.seq2reward_trainer import Seq2RewardTrainer
-from reagent.workflow.types import PreprocessingOptions
+from reagent.workflow.types import PreprocessingOptions, RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,10 @@ class Seq2RewardModel(WorldModelBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> Seq2RewardTrainer:
         # pyre-fixme[16]: `Seq2RewardModel` has no attribute `_seq2reward_network`.
         self._seq2reward_network = (

--- a/reagent/model_managers/model_based/seq2reward_model.py
+++ b/reagent/model_managers/model_based/seq2reward_model.py
@@ -45,8 +45,6 @@ class Seq2RewardModel(WorldModelBase):
 
     preprocessing_options: Optional[PreprocessingOptions] = None
 
-    # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
-    #  inconsistently.
     def build_trainer(
         self,
         normalization_data_map: Dict[str, NormalizationData],

--- a/reagent/model_managers/model_based/seq2reward_model.py
+++ b/reagent/model_managers/model_based/seq2reward_model.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import Seq2RewardTrainerParameters, param_hash
+from reagent.core.parameters import (
+    Seq2RewardTrainerParameters,
+    param_hash,
+    NormalizationKey,
+    NormalizationData,
+)
 from reagent.model_managers.world_model_base import WorldModelBase
 from reagent.net_builder.unions import ValueNetBuilder__Union
 from reagent.net_builder.value.fully_connected import FullyConnected
@@ -43,11 +48,15 @@ class Seq2RewardModel(WorldModelBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> Seq2RewardTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> Seq2RewardTrainer:
         # pyre-fixme[16]: `Seq2RewardModel` has no attribute `_seq2reward_network`.
         self._seq2reward_network = (
             seq2reward_network
-        ) = self.net_builder.value.build_value_network(self.state_normalization_data)
+        ) = self.net_builder.value.build_value_network(
+            normalization_data_map[NormalizationKey.STATE]
+        )
         trainer = Seq2RewardTrainer(
             seq2reward_network=seq2reward_network, params=self.trainer_param
         )

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -131,13 +131,15 @@ class SyntheticReward(ModelManager):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> RewardNetTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> RewardNetTrainer:
         net_builder = self.net_builder.value
         action_normalization_data = None
         if not self.discrete_action_names:
-            action_normalization_data = self.action_normalization_data
+            action_normalization_data = normalization_data_map[NormalizationKey.ACTION]
         synthetic_reward_network = net_builder.build_synthetic_reward_network(
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             action_normalization_data=action_normalization_data,
             discrete_action_names=self.discrete_action_names,
         )

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -158,7 +158,10 @@ class SyntheticReward(ModelManager):
             str(self.net_builder.value),
         )
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         """
         Returns a TorchScript predictor module
         """
@@ -169,11 +172,11 @@ class SyntheticReward(ModelManager):
         net_builder = self.net_builder.value
         action_normalization_data = None
         if not self.discrete_action_names:
-            action_normalization_data = self.action_normalization_data
+            action_normalization_data = normalization_data_map[NormalizationKey.ACTION]
         return net_builder.build_serving_module(
             self.max_seq_len,
             self._synthetic_reward_network,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             action_normalization_data=action_normalization_data,
             discrete_action_names=self.discrete_action_names,
         )

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -107,11 +107,6 @@ class SyntheticReward(ModelManager):
     def action_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.parametric_action_float_features)
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise RuntimeError
-
     def get_data_module(
         self,
         *,

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -96,10 +96,6 @@ class SyntheticReward(ModelManager):
             )
 
     @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise RuntimeError
-
-    @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.state_float_features)
 

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -123,12 +123,6 @@ class SyntheticReward(ModelManager):
             model_manager=self,
         )
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        if self.discrete_action_names:
-            return [NormalizationKey.STATE]
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
-
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
@@ -188,12 +182,6 @@ class SyntheticRewardDataModule(ManualDataModule):
     @property
     def should_generate_eval_dataset(self) -> bool:
         return self.model_manager.eval_parameters.calc_cpe_in_training
-
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        if self.model_manager.discrete_action_names:
-            return [NormalizationKey.STATE]
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
     def run_feature_identification(
         self, input_table_spec: TableSpec

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -154,7 +154,7 @@ class SyntheticReward(ModelManager):
 
     def get_reporter(self):
         return RewardNetworkReporter(
-            self.trainer.loss_type,
+            self.trainer_param.loss_type,
             str(self.net_builder.value),
         )
 

--- a/reagent/model_managers/model_based/synthetic_reward.py
+++ b/reagent/model_managers/model_based/synthetic_reward.py
@@ -126,7 +126,10 @@ class SyntheticReward(ModelManager):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> RewardNetTrainer:
         net_builder = self.net_builder.value
         action_normalization_data = None

--- a/reagent/model_managers/model_based/world_model.py
+++ b/reagent/model_managers/model_based/world_model.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
-import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import (
     MDNRNNTrainerParameters,
@@ -15,6 +14,7 @@ from reagent.model_managers.world_model_base import WorldModelBase
 from reagent.models.world_model import MemoryNetwork
 from reagent.preprocessing.normalization import get_num_output_features
 from reagent.training.world_model.mdnrnn_trainer import MDNRNNTrainer
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,10 @@ class WorldModel(WorldModelBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> MDNRNNTrainer:
         memory_network = MemoryNetwork(
             state_dim=get_num_output_features(

--- a/reagent/model_managers/model_based/world_model.py
+++ b/reagent/model_managers/model_based/world_model.py
@@ -41,9 +41,3 @@ class WorldModel(WorldModelBase):
             memory_network = memory_network.cuda()
 
         return MDNRNNTrainer(memory_network=memory_network, params=self.trainer_param)
-
-    def build_serving_module(self) -> torch.nn.Module:
-        """
-        Returns a TorchScript predictor module
-        """
-        raise NotImplementedError()

--- a/reagent/model_managers/model_based/world_model.py
+++ b/reagent/model_managers/model_based/world_model.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 
 import logging
+from typing import Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import MDNRNNTrainerParameters, param_hash
+from reagent.core.parameters import (
+    MDNRNNTrainerParameters,
+    param_hash,
+    NormalizationData,
+    NormalizationKey,
+)
 from reagent.model_managers.world_model_base import WorldModelBase
 from reagent.models.world_model import MemoryNetwork
 from reagent.preprocessing.normalization import get_num_output_features
@@ -27,10 +33,14 @@ class WorldModel(WorldModelBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> MDNRNNTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> MDNRNNTrainer:
         memory_network = MemoryNetwork(
             state_dim=get_num_output_features(
-                self.state_normalization_data.dense_normalization_parameters
+                normalization_data_map[
+                    NormalizationKey.STATE
+                ].dense_normalization_parameters
             ),
             action_dim=self.trainer_param.action_dim,
             num_hiddens=self.trainer_param.hidden_size,

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -118,21 +118,6 @@ class ModelManager:
             f"attr {attr} not available {type(self)} (subclass of ModelManager)."
         )
 
-    @abc.abstractmethod
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        """
-        DEPRECATED: Implement get_data_module() instead
-
-        Massage input table into the format expected by the trainer
-        """
-        pass
-
     @property
     def trainer(self) -> Trainer:
         """

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -55,21 +55,9 @@ class ModelManager:
 
     def __post_init_post_parse__(self):
         # initialization is delayed to `initialize_trainer()`
-        self._reward_options: Optional[RewardOptions] = None
         self._trainer: Optional[Trainer] = None
         self._lightning_trainer: Optional[pl.Trainer] = None
         self._lightning_checkpoint_path: Optional[str] = None
-
-    @property
-    def reward_options(self) -> RewardOptions:
-        assert self._reward_options is not None
-        return self._reward_options
-
-    @reward_options.setter
-    def reward_options(self, reward_options: RewardOptions):
-        assert self._reward_options is None
-        # pyre-fixme[16]: `ModelManager` has no attribute `_reward_options`.
-        self._reward_options = reward_options
 
     def get_data_module(
         self,
@@ -115,9 +103,9 @@ class ModelManager:
         Initialize the trainer. Subclass should not override this. Instead,
         subclass should implement `build_trainer()`.
         """
-        assert self._trainer is None, "Trainer was intialized"
-        self.reward_options = reward_options
-        trainer = self.build_trainer(normalization_data_map, use_gpu=use_gpu)
+        trainer = self.build_trainer(
+            normalization_data_map, reward_options=reward_options, use_gpu=use_gpu
+        )
         # pyre-fixme[16]: `ModelManager` has no attribute `_trainer`.
         self._trainer = trainer
         if warmstart_path is not None:
@@ -131,7 +119,10 @@ class ModelManager:
 
     @abc.abstractmethod
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> Trainer:
         """
         Implement this to build the trainer, given the config

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -89,18 +89,6 @@ class ModelManager:
         """
         return None
 
-    @abc.abstractmethod
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        """
-        DEPRECATED: Implement get_data_module() instead
-
-        Derive preprocessing parameters from data. The keys of the dict should
-        match the keys from `required_normalization_keys()`
-        """
-        pass
-
     @property
     @abc.abstractmethod
     def required_normalization_keys(self) -> List[str]:

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -118,14 +118,6 @@ class ModelManager:
             f"attr {attr} not available {type(self)} (subclass of ModelManager)."
         )
 
-    @property
-    @abc.abstractmethod
-    def should_generate_eval_dataset(self) -> bool:
-        """
-        DEPRECATED: Implement get_data_module() instead
-        """
-        pass
-
     @abc.abstractmethod
     def query_data(
         self,

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -2,13 +2,12 @@
 
 import abc
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import pytorch_lightning as pl
 import torch
 from reagent.core.dataclasses import dataclass
 from reagent.core.parameters import NormalizationData
-from reagent.data.data_fetcher import DataFetcher
 from reagent.data.reagent_data_module import ReAgentDataModule
 from reagent.training import Trainer
 from reagent.workflow.types import (
@@ -218,13 +217,23 @@ class ModelManager:
         pass
 
     # TODO: make abstract
-    # TODO: This function should take normalization_data_map &
-    # dictionary of modules created in `build_trainer()`
-    def build_serving_modules(self) -> Dict[str, torch.nn.Module]:
+    def build_serving_modules(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> Dict[str, torch.nn.Module]:
         """
         Returns TorchScript for serving in production
         """
-        return {"default_model": self.build_serving_module()}
+        return {"default_model": self.build_serving_module(normalization_data_map)}
+
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
+        """
+        Optionaly, implement this method if you only have one model for serving
+        """
+        raise NotImplementedError
 
     # TODO: make abstract
     def serving_module_names(self) -> List[str]:

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -2,14 +2,15 @@
 
 import abc
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import pytorch_lightning as pl
 import torch
 from reagent.core.dataclasses import dataclass
 from reagent.core.parameters import NormalizationData
 from reagent.data.reagent_data_module import ReAgentDataModule
-from reagent.training import Trainer
+from reagent.reporting.reporter_base import ReporterBase
+from reagent.training import ReAgentLightningModule
 from reagent.workflow.types import (
     Dataset,
     ReaderOptions,
@@ -18,6 +19,8 @@ from reagent.workflow.types import (
     RLTrainingOutput,
     TableSpec,
 )
+from reagent.workflow.types import RLTrainingReport
+from reagent.workflow.utils import get_rank, train_eval_lightning
 
 
 logger = logging.getLogger(__name__)
@@ -54,10 +57,14 @@ class ModelManager:
     """
 
     def __post_init_post_parse__(self):
-        # initialization is delayed to `initialize_trainer()`
-        self._trainer: Optional[Trainer] = None
-        self._lightning_trainer: Optional[pl.Trainer] = None
-        self._lightning_checkpoint_path: Optional[str] = None
+        """
+        We use pydantic to parse raw config into typed (dataclass) config.
+        This method is called after everything is parsed, so you could
+        validate constraints that may not be captured with the type alone.
+
+        See https://pydantic-docs.helpmanual.io/usage/dataclasses/#initialize-hooks
+        """
+        pass
 
     def get_data_module(
         self,
@@ -75,55 +82,13 @@ class ModelManager:
         """
         return None
 
-    @property
-    def trainer(self) -> Trainer:
-        """
-        DEPRECATED: The build_trainer() function should also return
-        a dictionary of created networks so that other functions can
-        refer to them.
-
-        Get access to the training module. This is mostly used to extract networks
-        in build_serving_modules() & create_policy().
-        """
-        assert self._trainer is not None, "Call initialize_trainer() first"
-        return self._trainer
-
-    def initialize_trainer(
-        self,
-        use_gpu: bool,
-        reward_options: RewardOptions,
-        normalization_data_map: Dict[str, NormalizationData],
-        warmstart_path: Optional[str] = None,
-    ) -> Trainer:
-        """
-        DEPRECATED: This should be baked into the train() function.
-        `normalization_data_map` is used in build_serving_modules().
-        We can pass it there directly.
-
-        Initialize the trainer. Subclass should not override this. Instead,
-        subclass should implement `build_trainer()`.
-        """
-        trainer = self.build_trainer(
-            normalization_data_map, reward_options=reward_options, use_gpu=use_gpu
-        )
-        # pyre-fixme[16]: `ModelManager` has no attribute `_trainer`.
-        self._trainer = trainer
-        if warmstart_path is not None:
-            if isinstance(trainer, pl.LightningModule):
-                # Delayed until Trainer is initialized
-                self._lightning_checkpoint_path = warmstart_path
-            else:
-                trainer_state = torch.load(warmstart_path)
-                trainer.load_state_dict(trainer_state)
-        return trainer
-
     @abc.abstractmethod
     def build_trainer(
         self,
         normalization_data_map: Dict[str, NormalizationData],
         use_gpu: bool,
         reward_options: Optional[RewardOptions] = None,
-    ) -> Trainer:
+    ) -> ReAgentLightningModule:
         """
         Implement this to build the trainer, given the config
 
@@ -132,12 +97,13 @@ class ModelManager:
         """
         pass
 
-    def destroy_trainer(self):
-        self._trainer = None
-
     @abc.abstractmethod
+    def get_reporter(self) -> ReporterBase:
+        pass
+
     def train(
         self,
+        trainer_module: ReAgentLightningModule,
         train_dataset: Optional[Dataset],
         eval_dataset: Optional[Dataset],
         test_dataset: Optional[Dataset],
@@ -145,13 +111,15 @@ class ModelManager:
         num_epochs: int,
         reader_options: ReaderOptions,
         resource_options: ResourceOptions,
-    ) -> RLTrainingOutput:
+        checkpoint_path: Optional[str] = None,
+    ) -> Tuple[RLTrainingOutput, pl.Trainer]:
         """
-        DEPRECATED: Delete this once every trainer is built on PyTorch Lightning &
-        every ModelManager implemnts get_data_module(). Then, we can just move the code
-        in train() of DiscreteDQNBase into the training workflow function
-
         Train the model
+
+        Returns partially filled RLTrainingOutput.
+        The field that should not be filled are:
+        - output_path
+
         Arguments:
             train/eval/test_dataset: what you'd expect
             data_module: [pytorch lightning only] a lightning data module that replaces the use of train/eval datasets
@@ -159,20 +127,63 @@ class ModelManager:
             reader_options: options for the data reader
             resource_options: options for training resources (currently only used for setting num_nodes in pytorch lightning trainer)
         """
-        pass
+        reporter = self.get_reporter()
+        trainer_module.set_reporter(reporter)
+        assert data_module
+
+        lightning_trainer = train_eval_lightning(
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            test_dataset=test_dataset,
+            trainer_module=trainer_module,
+            data_module=data_module,
+            num_epochs=num_epochs,
+            logger_name=str(type(self)),
+            reader_options=reader_options,
+            checkpoint_path=checkpoint_path,
+            resource_options=resource_options,
+        )
+        rank = get_rank()
+        if rank == 0:
+            logger = lightning_trainer.logger
+            # pyre-ignore
+            logger_data = logger.line_plot_aggregated
+            # pyre-ignore
+            logger.clear_local_data()
+            if reporter is None:
+                training_report = None
+            else:
+                # pyre-ignore
+                training_report = RLTrainingReport.make_union_instance(
+                    reporter.generate_training_report()
+                )
+            return (
+                RLTrainingOutput(
+                    training_report=training_report, logger_data=logger_data
+                ),
+                lightning_trainer,
+            )
+        # Output from processes with non-0 rank is not used
+        return RLTrainingOutput(), lightning_trainer
 
     # TODO: make abstract
     def build_serving_modules(
         self,
+        trainer_module: ReAgentLightningModule,
         normalization_data_map: Dict[str, NormalizationData],
     ) -> Dict[str, torch.nn.Module]:
         """
         Returns TorchScript for serving in production
         """
-        return {"default_model": self.build_serving_module(normalization_data_map)}
+        return {
+            "default_model": self.build_serving_module(
+                trainer_module, normalization_data_map
+            )
+        }
 
     def build_serving_module(
         self,
+        trainer_module: ReAgentLightningModule,
         normalization_data_map: Dict[str, NormalizationData],
     ) -> torch.nn.Module:
         """
@@ -188,3 +199,11 @@ class ModelManager:
         these serving modules before we start the training.
         """
         return ["default_model"]
+
+    def create_policy(
+        self,
+        trainer_module: ReAgentLightningModule,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ):
+        raise NotImplementedError

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -165,7 +165,7 @@ class ModelManager:
         ), "Cannot reset self._normalization_data_map"
         # pyre-fixme[16]: `ModelManager` has no attribute `_normalization_data_map`.
         self._normalization_data_map = normalization_data_map
-        trainer = self.build_trainer(use_gpu=use_gpu)
+        trainer = self.build_trainer(normalization_data_map, use_gpu=use_gpu)
         # pyre-fixme[16]: `ModelManager` has no attribute `_trainer`.
         self._trainer = trainer
         if warmstart_path is not None:
@@ -178,7 +178,9 @@ class ModelManager:
         return trainer
 
     @abc.abstractmethod
-    def build_trainer(self, use_gpu: bool) -> Trainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> Trainer:
         """
         Implement this to build the trainer, given the config
 

--- a/reagent/model_managers/parametric/parametric_dqn.py
+++ b/reagent/model_managers/parametric/parametric_dqn.py
@@ -35,17 +35,20 @@ class ParametricDQN(ParametricDQNBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> ParametricDQNTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> ParametricDQNTrainer:
         net_builder = self.net_builder.value
         # pyre-fixme[16]: `ParametricDQN` has no attribute `_q_network`.
         self._q_network = net_builder.build_q_network(
-            self.state_normalization_data, self.action_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )
         # Metrics + reward
         reward_output_dim = len(self.metrics_to_score) + 1
         reward_network = net_builder.build_q_network(
-            self.state_normalization_data,
-            self.action_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
             output_dim=reward_output_dim,
         )
 

--- a/reagent/model_managers/parametric/parametric_dqn.py
+++ b/reagent/model_managers/parametric/parametric_dqn.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import param_hash, NormalizationData, NormalizationKey
+from reagent.evaluation.evaluator import get_metrics_to_score
 from reagent.model_managers.parametric_dqn_base import ParametricDQNBase
 from reagent.net_builder.parametric_dqn.fully_connected import FullyConnected
 from reagent.net_builder.unions import ParametricDQNNetBuilder__Union
 from reagent.training import ParametricDQNTrainer, ParametricDQNTrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,10 @@ class ParametricDQN(ParametricDQNBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> ParametricDQNTrainer:
         net_builder = self.net_builder.value
         # pyre-fixme[16]: `ParametricDQN` has no attribute `_q_network`.
@@ -45,7 +50,9 @@ class ParametricDQN(ParametricDQNBase):
             normalization_data_map[NormalizationKey.ACTION],
         )
         # Metrics + reward
-        reward_output_dim = len(self.metrics_to_score) + 1
+        reward_options = reward_options or RewardOptions()
+        metrics_to_score = get_metrics_to_score(reward_options.metric_reward_values)
+        reward_output_dim = len(metrics_to_score) + 1
         reward_network = net_builder.build_q_network(
             normalization_data_map[NormalizationKey.STATE],
             normalization_data_map[NormalizationKey.ACTION],

--- a/reagent/model_managers/parametric/parametric_dqn.py
+++ b/reagent/model_managers/parametric/parametric_dqn.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import logging
+from typing import Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import param_hash
+from reagent.core.parameters import param_hash, NormalizationData, NormalizationKey
 from reagent.model_managers.parametric_dqn_base import ParametricDQNBase
 from reagent.net_builder.parametric_dqn.fully_connected import FullyConnected
 from reagent.net_builder.unions import ParametricDQNNetBuilder__Union
@@ -58,11 +59,14 @@ class ParametricDQN(ParametricDQNBase):
             **self.trainer_param.asdict(),
         )
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         net_builder = self.net_builder.value
         assert self._q_network is not None
         return net_builder.build_serving_module(
             self._q_network,
-            self.state_normalization_data,
-            self.action_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ACTION],
         )

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -13,7 +13,6 @@ from reagent.core.parameters import (
 from reagent.data.data_fetcher import DataFetcher
 from reagent.data.manual_data_module import ManualDataModule
 from reagent.data.reagent_data_module import ReAgentDataModule
-from reagent.evaluation.evaluator import get_metrics_to_score
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.gym.policies.samplers.discrete_sampler import SoftmaxActionSampler
@@ -23,7 +22,6 @@ from reagent.models.base import ModelBase
 from reagent.preprocessing.batch_preprocessor import BatchPreprocessor
 from reagent.preprocessing.normalization import (
     get_feature_config,
-    get_num_output_features,
 )
 from reagent.preprocessing.types import InputColumn
 from reagent.workflow.identify_types_flow import identify_normalization_parameters
@@ -66,7 +64,6 @@ class ParametricDQNBase(ModelManager):
             "config instead"
         )
         self._q_network: Optional[ModelBase] = None
-        self._metrics_to_score: Optional[List[str]] = None
 
     def create_policy(
         self,
@@ -98,16 +95,6 @@ class ParametricDQNBase(ModelManager):
     @property
     def action_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.action_float_features)
-
-    @property
-    def metrics_to_score(self) -> List[str]:
-        assert self.reward_options is not None
-        if self._metrics_to_score is None:
-            # pyre-fixme[16]: `ParametricDQNBase` has no attribute `_metrics_to_score`.
-            self._metrics_to_score = get_metrics_to_score(
-                self._reward_options.metric_reward_values
-            )
-        return self._metrics_to_score
 
     # TODO: Add below get_data_module() method once methods in
     # `ParametricDqnDataModule` class are fully implemented

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -100,10 +100,6 @@ class ParametricDQNBase(ModelManager):
         return get_feature_config(self.action_float_features)
 
     @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
-
-    @property
     def metrics_to_score(self) -> List[str]:
         assert self.reward_options is not None
         if self._metrics_to_score is None:
@@ -152,10 +148,6 @@ class ParametricDqnDataModule(ManualDataModule):
     @property
     def should_generate_eval_dataset(self) -> bool:
         return self.model_manager.eval_parameters.calc_cpe_in_training
-
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
     def run_feature_identification(
         self, input_table_spec: TableSpec

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -87,10 +87,6 @@ class ParametricDQNBase(ModelManager):
             return Policy(scorer=scorer, sampler=sampler)
 
     @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise RuntimeError
-
-    @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.state_float_features)
 

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -98,15 +98,6 @@ class ParametricDQNBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise RuntimeError
-
     @property
     def metrics_to_score(self) -> List[str]:
         assert self.reward_options is not None

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -117,9 +117,6 @@ class ParametricDQNBase(ModelManager):
             )
         return self._metrics_to_score
 
-    def build_batch_preprocessor(self) -> BatchPreprocessor:
-        raise NotImplementedError()
-
     # TODO: Add below get_data_module() method once methods in
     # `ParametricDqnDataModule` class are fully implemented
     # def get_data_module(
@@ -217,5 +214,5 @@ class ParametricDqnDataModule(ManualDataModule):
     ) -> Dataset:
         raise NotImplementedError
 
-    def build_batch_preprocessor(self, use_gpu: bool) -> BatchPreprocessor:
+    def build_batch_preprocessor(self) -> BatchPreprocessor:
         raise NotImplementedError()

--- a/reagent/model_managers/parametric_dqn_base.py
+++ b/reagent/model_managers/parametric_dqn_base.py
@@ -98,11 +98,6 @@ class ParametricDQNBase(ModelManager):
     def action_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.action_float_features)
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise RuntimeError
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -117,10 +117,6 @@ class PPO(ModelManager):
         )
         return policy_serving_module
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE]
-
     def train(
         self,
         train_dataset: Optional[Dataset],

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -105,11 +105,6 @@ class PPO(ModelManager):
         )
         return policy_serving_module
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise NotImplementedError
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -29,7 +29,6 @@ from reagent.workflow.types import (
     ResourceOptions,
     RewardOptions,
     RLTrainingOutput,
-    TableSpec,
 )
 
 
@@ -57,15 +56,21 @@ class PPO(ModelManager):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self.action_names = self.trainer_param.actions
         self._policy: Optional[Policy] = None
         assert (
             len(self.action_names) > 1
         ), f"PPO needs at least 2 actions. Got {self.action_names}."
 
+    @property
+    def action_names(self):
+        return self.trainer_param.action_names
+
     # pyre-ignore
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> PPOTrainer:
         policy_net_builder = self.policy_net_builder.value
         # pyre-ignore

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -109,15 +109,6 @@ class PPO(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise NotImplementedError
-
     def train(
         self,
         train_dataset: Optional[Dataset],

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -109,10 +109,6 @@ class PPO(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 
-    @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise NotImplementedError
-
     def query_data(
         self,
         input_table_spec: TableSpec,

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -64,19 +64,21 @@ class PPO(ModelManager):
         ), f"PPO needs at least 2 actions. Got {self.action_names}."
 
     # pyre-ignore
-    def build_trainer(self, use_gpu: bool) -> PPOTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> PPOTrainer:
         policy_net_builder = self.policy_net_builder.value
         # pyre-ignore
         self._policy_network = policy_net_builder.build_q_network(
             self.state_feature_config,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
         )
         value_net = None
         if self.value_net_builder:
             value_net_builder = self.value_net_builder.value  # pyre-ignore
             value_net = value_net_builder.build_value_network(
-                self.state_normalization_data
+                normalization_data_map[NormalizationKey.STATE]
             )
         trainer = PPOTrainer(
             policy=self.create_policy(),

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -107,11 +107,6 @@ class Reinforce(ModelManager):
         )
         return policy_serving_module
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise NotImplementedError
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -58,15 +58,21 @@ class Reinforce(ModelManager):
 
     def __post_init_post_parse__(self):
         super().__post_init_post_parse__()
-        self.action_names = self.trainer_param.actions
         self._policy: Optional[Policy] = None
         assert (
             len(self.action_names) > 1
         ), f"REINFORCE needs at least 2 actions. Got {self.action_names}."
 
+    @property
+    def action_names(self):
+        return self.trainer_param.action_names
+
     # pyre-ignore
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> ReinforceTrainer:
         policy_net_builder = self.policy_net_builder.value
         # pyre-ignore

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -86,9 +86,16 @@ class Reinforce(ModelManager):
         )
         return trainer
 
-    def create_policy(self, serving: bool = False):
+    def create_policy(
+        self,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ):
         if serving:
-            return create_predictor_policy_from_model(self.build_serving_module())
+            assert normalization_data_map is not None
+            return create_predictor_policy_from_model(
+                self.build_serving_module(normalization_data_map)
+            )
         else:
             if self._policy is None:
                 sampler = SoftmaxActionSampler(temperature=self.sampler_temperature)
@@ -96,11 +103,14 @@ class Reinforce(ModelManager):
                 self._policy = Policy(scorer=self._policy_network, sampler=sampler)
             return self._policy
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         assert self._policy_network is not None
         policy_serving_module = self.policy_net_builder.value.build_serving_module(
             q_network=self._policy_network,
-            state_normalization_data=self.state_normalization_data,
+            state_normalization_data=normalization_data_map[NormalizationKey.STATE],
             action_names=self.action_names,
             state_feature_config=self.state_feature_config,
         )

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -111,10 +111,6 @@ class Reinforce(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
 
-    @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise NotImplementedError
-
     def query_data(
         self,
         input_table_spec: TableSpec,

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -21,6 +21,7 @@ from reagent.net_builder.unions import (
     DiscreteDQNNetBuilder__Union,
     ValueNetBuilder__Union,
 )
+from reagent.training import ReAgentLightningModule
 from reagent.training import ReinforceTrainer, ReinforceTrainerParameters
 from reagent.workflow.types import (
     Dataset,
@@ -65,9 +66,8 @@ class Reinforce(ModelManager):
 
     @property
     def action_names(self):
-        return self.trainer_param.action_names
+        return self.trainer_param.actions
 
-    # pyre-ignore
     def build_trainer(
         self,
         normalization_data_map: Dict[str, NormalizationData],
@@ -75,8 +75,7 @@ class Reinforce(ModelManager):
         reward_options: Optional[RewardOptions] = None,
     ) -> ReinforceTrainer:
         policy_net_builder = self.policy_net_builder.value
-        # pyre-ignore
-        self._policy_network = policy_net_builder.build_q_network(
+        policy_network = policy_net_builder.build_q_network(
             self.state_feature_config,
             normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
@@ -88,7 +87,7 @@ class Reinforce(ModelManager):
                 normalization_data_map[NormalizationKey.STATE]
             )
         trainer = ReinforceTrainer(
-            policy=self.create_policy(),
+            policy=self._create_policy(policy_network),
             value_net=value_net,
             **self.trainer_param.asdict(),  # pyre-ignore
         )
@@ -96,45 +95,38 @@ class Reinforce(ModelManager):
 
     def create_policy(
         self,
+        trainer_module: ReAgentLightningModule,
         serving: bool = False,
         normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
     ):
+        assert isinstance(trainer_module, ReinforceTrainer)
         if serving:
             assert normalization_data_map is not None
             return create_predictor_policy_from_model(
-                self.build_serving_module(normalization_data_map)
+                self.build_serving_module(trainer_module, normalization_data_map)
             )
         else:
-            if self._policy is None:
-                sampler = SoftmaxActionSampler(temperature=self.sampler_temperature)
-                # pyre-ignore
-                self._policy = Policy(scorer=self._policy_network, sampler=sampler)
-            return self._policy
+            return self._create_policy(trainer_module.scorer)
+
+    def _create_policy(self, policy_network):
+        if self._policy is None:
+            sampler = SoftmaxActionSampler(temperature=self.sampler_temperature)
+            self._policy = Policy(scorer=policy_network, sampler=sampler)
+        return self._policy
 
     def build_serving_module(
         self,
+        trainer_module: ReAgentLightningModule,
         normalization_data_map: Dict[str, NormalizationData],
     ) -> torch.nn.Module:
-        assert self._policy_network is not None
+        assert isinstance(trainer_module, ReinforceTrainer)
         policy_serving_module = self.policy_net_builder.value.build_serving_module(
-            q_network=self._policy_network,
+            q_network=trainer_module.scorer,
             state_normalization_data=normalization_data_map[NormalizationKey.STATE],
             action_names=self.action_names,
             state_feature_config=self.state_feature_config,
         )
         return policy_serving_module
-
-    def train(
-        self,
-        train_dataset: Optional[Dataset],
-        eval_dataset: Optional[Dataset],
-        test_dataset: Optional[Dataset],
-        data_module: Optional[ReAgentDataModule],
-        num_epochs: int,
-        reader_options: ReaderOptions,
-        resource_options: ResourceOptions,
-    ) -> RLTrainingOutput:
-        raise NotImplementedError
 
     @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -29,7 +29,6 @@ from reagent.workflow.types import (
     ResourceOptions,
     RewardOptions,
     RLTrainingOutput,
-    TableSpec,
 )
 
 
@@ -110,15 +109,6 @@ class Reinforce(ModelManager):
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE]
-
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise NotImplementedError
 
     def train(
         self,

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -118,10 +118,6 @@ class Reinforce(ModelManager):
         )
         return policy_serving_module
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE]
-
     def train(
         self,
         train_dataset: Optional[Dataset],

--- a/reagent/model_managers/policy_gradient/reinforce.py
+++ b/reagent/model_managers/policy_gradient/reinforce.py
@@ -65,19 +65,21 @@ class Reinforce(ModelManager):
         ), f"REINFORCE needs at least 2 actions. Got {self.action_names}."
 
     # pyre-ignore
-    def build_trainer(self, use_gpu: bool) -> ReinforceTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> ReinforceTrainer:
         policy_net_builder = self.policy_net_builder.value
         # pyre-ignore
         self._policy_network = policy_net_builder.build_q_network(
             self.state_feature_config,
-            self.state_normalization_data,
+            normalization_data_map[NormalizationKey.STATE],
             len(self.action_names),
         )
         value_net = None
         if self.value_net_builder:
             value_net_builder = self.value_net_builder.value  # pyre-ignore
             value_net = value_net_builder.build_value_network(
-                self.state_normalization_data
+                normalization_data_map[NormalizationKey.STATE]
             )
         trainer = ReinforceTrainer(
             policy=self.create_policy(),

--- a/reagent/model_managers/ranking/slate_q.py
+++ b/reagent/model_managers/ranking/slate_q.py
@@ -45,14 +45,15 @@ class SlateQ(SlateQBase):
 
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
-    def build_trainer(self, use_gpu: bool) -> SlateQTrainer:
+    def build_trainer(
+        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+    ) -> SlateQTrainer:
         net_builder = self.net_builder.value
         # pyre-fixme[16]: `SlateQ` has no attribute `_q_network`.
         self._q_network = net_builder.build_q_network(
-            self.state_normalization_data, self.item_normalization_data
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ITEM],
         )
-        if use_gpu:
-            self._q_network = self._q_network.cuda()
 
         q_network_target = self._q_network.get_target_network()
         return SlateQTrainer(

--- a/reagent/model_managers/ranking/slate_q.py
+++ b/reagent/model_managers/ranking/slate_q.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 import torch
 from reagent.core.dataclasses import dataclass, field
-from reagent.core.parameters import param_hash
+from reagent.core.parameters import param_hash, NormalizationData, NormalizationKey
 from reagent.model_managers.slate_q_base import SlateQBase
 from reagent.models.base import ModelBase
 from reagent.net_builder.parametric_dqn.fully_connected import FullyConnected
@@ -62,9 +62,14 @@ class SlateQ(SlateQBase):
             **self.trainer_param.asdict(),
         )
 
-    def build_serving_module(self) -> torch.nn.Module:
+    def build_serving_module(
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+    ) -> torch.nn.Module:
         net_builder = self.net_builder.value
         assert self._q_network is not None
         return net_builder.build_serving_module(
-            self._q_network, self.state_normalization_data, self.item_normalization_data
+            self._q_network,
+            normalization_data_map[NormalizationKey.STATE],
+            normalization_data_map[NormalizationKey.ITEM],
         )

--- a/reagent/model_managers/ranking/slate_q.py
+++ b/reagent/model_managers/ranking/slate_q.py
@@ -11,6 +11,7 @@ from reagent.models.base import ModelBase
 from reagent.net_builder.parametric_dqn.fully_connected import FullyConnected
 from reagent.net_builder.unions import ParametricDQNNetBuilder__Union
 from reagent.training import SlateQTrainer, SlateQTrainerParameters
+from reagent.workflow.types import RewardOptions
 
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,10 @@ class SlateQ(SlateQBase):
     # pyre-fixme[15]: `build_trainer` overrides method defined in `ModelManager`
     #  inconsistently.
     def build_trainer(
-        self, normalization_data_map: Dict[str, NormalizationData], use_gpu: bool
+        self,
+        normalization_data_map: Dict[str, NormalizationData],
+        use_gpu: bool,
+        reward_options: Optional[RewardOptions] = None,
     ) -> SlateQTrainer:
         net_builder = self.net_builder.value
         # pyre-fixme[16]: `SlateQ` has no attribute `_q_network`.

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -5,8 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import reagent.core.types as rlt
 from reagent.core.dataclasses import dataclass
 from reagent.core.parameters import NormalizationData, NormalizationKey
-from reagent.data.data_fetcher import DataFetcher
-from reagent.data.reagent_data_module import ReAgentDataModule
+from reagent.data import DataFetcher, ReAgentDataModule
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.gym.policies.samplers.top_k_sampler import TopKSampler
@@ -14,9 +13,7 @@ from reagent.gym.policies.scorers.slate_q_scorer import slate_q_scorer
 from reagent.model_managers.model_manager import ModelManager
 from reagent.models.base import ModelBase
 from reagent.preprocessing.normalization import get_feature_config
-from reagent.preprocessing.types import InputColumn
 from reagent.reporting.slate_q_reporter import SlateQReporter
-from reagent.workflow.identify_types_flow import identify_normalization_parameters
 from reagent.workflow.types import (
     Dataset,
     PreprocessingOptions,
@@ -81,7 +78,7 @@ class SlateQBase(ModelManager):
 
     @property
     def should_generate_eval_dataset(self) -> bool:
-        return self.eval_parameters.calc_cpe_in_training
+        raise RuntimeError
 
     @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
@@ -94,43 +91,7 @@ class SlateQBase(ModelManager):
     def run_feature_identification(
         self, input_table_spec: TableSpec
     ) -> Dict[str, NormalizationData]:
-        state_preprocessing_options = (
-            self._state_preprocessing_options or PreprocessingOptions()
-        )
-        state_features = [
-            ffi.feature_id for ffi in self.state_feature_config.float_feature_infos
-        ]
-        logger.info(f"state allowedlist_features: {state_features}")
-        state_preprocessing_options = state_preprocessing_options._replace(
-            allowedlist_features=state_features
-        )
-        state_normalization_parameters = identify_normalization_parameters(
-            input_table_spec, InputColumn.STATE_FEATURES, state_preprocessing_options
-        )
-        item_preprocessing_options = (
-            self._item_preprocessing_options or PreprocessingOptions()
-        )
-        item_features = [
-            ffi.feature_id for ffi in self.item_feature_config.float_feature_infos
-        ]
-        logger.info(f"item allowedlist_features: {item_features}")
-        item_preprocessing_options = item_preprocessing_options._replace(
-            allowedlist_features=item_features,
-            sequence_feature_id=self.slate_feature_id,
-        )
-        item_normalization_parameters = identify_normalization_parameters(
-            input_table_spec,
-            InputColumn.STATE_SEQUENCE_FEATURES,
-            item_preprocessing_options,
-        )
-        return {
-            NormalizationKey.STATE: NormalizationData(
-                dense_normalization_parameters=state_normalization_parameters
-            ),
-            NormalizationKey.ITEM: NormalizationData(
-                dense_normalization_parameters=item_normalization_parameters
-            ),
-        }
+        raise RuntimeError
 
     @property
     def required_normalization_keys(self) -> List[str]:
@@ -143,7 +104,7 @@ class SlateQBase(ModelManager):
         reward_options: RewardOptions,
         data_fetcher: DataFetcher,
     ) -> Dataset:
-        raise NotImplementedError("Write for OSS")
+        raise RuntimeError
 
     def get_reporter(self):
         return SlateQReporter()

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -88,15 +88,6 @@ class SlateQBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ITEM]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise RuntimeError
-
     def get_reporter(self):
         return SlateQReporter()
 

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -89,10 +89,6 @@ class SlateQBase(ModelManager):
     def item_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.item_float_features)
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE, NormalizationKey.ITEM]
-
     def get_reporter(self):
         return SlateQReporter()
 

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -77,10 +77,6 @@ class SlateQBase(ModelManager):
             return Policy(scorer=scorer, sampler=sampler)
 
     @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise RuntimeError
-
-    @property
     def state_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.state_float_features)
 

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -88,11 +88,6 @@ class SlateQBase(ModelManager):
     def item_feature_config(self) -> rlt.ModelFeatureConfig:
         return get_feature_config(self.item_float_features)
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise RuntimeError
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ITEM]

--- a/reagent/model_managers/slate_q_base.py
+++ b/reagent/model_managers/slate_q_base.py
@@ -62,10 +62,15 @@ class SlateQBase(ModelManager):
         self._q_network: Optional[ModelBase] = None
         self.eval_parameters = self.trainer_param.evaluation
 
-    def create_policy(self, serving: bool) -> Policy:
+    def create_policy(
+        self,
+        serving: bool = False,
+        normalization_data_map: Optional[Dict[str, NormalizationData]] = None,
+    ):
         if serving:
+            assert normalization_data_map
             return create_predictor_policy_from_model(
-                self.build_serving_module(),
+                self.build_serving_module(normalization_data_map),
                 max_num_actions=self.num_candidates,
                 slate_size=self.slate_size,
             )

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -34,10 +34,6 @@ logger = logging.getLogger(__name__)
 class WorldModelBase(ModelManager):
     reward_boost: Optional[Dict[str, float]] = None
 
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE, NormalizationKey.ACTION]
-
     # TODO: Add get_data_module() method once methods in
     # `WorldModelDataModule` class are implemented
     # def get_data_module(
@@ -87,10 +83,6 @@ class WorldModelDataModule(ManualDataModule):
     @property
     def should_generate_eval_dataset(self) -> bool:
         return False
-
-    @property
-    def required_normalization_keys(self) -> List[str]:
-        return [NormalizationKey.STATE]
 
     def run_feature_identification(
         self, input_table_spec: TableSpec

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -56,28 +56,6 @@ class WorldModelBase(ModelManager):
     #         model_manager=self,
     #     )
 
-    def train(
-        self,
-        train_dataset: Optional[Dataset],
-        eval_dataset: Optional[Dataset],
-        test_dataset: Optional[Dataset],
-        data_module: Optional[ReAgentDataModule],
-        num_epochs: int,
-        reader_options: ReaderOptions,
-        resource_options: ResourceOptions,
-    ) -> RLTrainingOutput:
-        """
-        Train the model
-
-        Returns partially filled RLTrainingOutput. The field that should not be filled
-        are:
-        - output_path
-        - warmstart_output_path
-        - vis_metrics
-        - validation_output
-        """
-        raise NotImplementedError()
-
 
 class WorldModelDataModule(ManualDataModule):
     @property

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -43,10 +43,6 @@ class WorldModelBase(ModelManager):
         raise NotImplementedError()
 
     @property
-    def should_generate_eval_dataset(self) -> bool:
-        raise RuntimeError
-
-    @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]
 

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -50,11 +50,6 @@ class WorldModelBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
-    def run_feature_identification(
-        self, input_table_spec: TableSpec
-    ) -> Dict[str, NormalizationData]:
-        raise RuntimeError
-
     def query_data(
         self,
         input_table_spec: TableSpec,

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -34,14 +34,6 @@ logger = logging.getLogger(__name__)
 class WorldModelBase(ModelManager):
     reward_boost: Optional[Dict[str, float]] = None
 
-    @classmethod
-    def normalization_key(cls) -> str:
-        raise NotImplementedError()
-
-    def create_policy(self) -> Policy:
-        """Create a WorldModel Policy from env."""
-        raise NotImplementedError()
-
     @property
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -55,9 +55,6 @@ class WorldModelBase(ModelManager):
     ) -> Dataset:
         raise RuntimeError
 
-    def build_batch_preprocessor(self) -> BatchPreprocessor:
-        raise RuntimeError
-
     # TODO: Add get_data_module() method once methods in
     # `WorldModelDataModule` class are implemented
     # def get_data_module(

--- a/reagent/model_managers/world_model_base.py
+++ b/reagent/model_managers/world_model_base.py
@@ -46,15 +46,6 @@ class WorldModelBase(ModelManager):
     def required_normalization_keys(self) -> List[str]:
         return [NormalizationKey.STATE, NormalizationKey.ACTION]
 
-    def query_data(
-        self,
-        input_table_spec: TableSpec,
-        sample_range: Optional[Tuple[float, float]],
-        reward_options: RewardOptions,
-        data_fetcher: DataFetcher,
-    ) -> Dataset:
-        raise RuntimeError
-
     # TODO: Add get_data_module() method once methods in
     # `WorldModelDataModule` class are implemented
     # def get_data_module(

--- a/reagent/workflow/training.py
+++ b/reagent/workflow/training.py
@@ -219,6 +219,7 @@ def train_workflow(
     if setup_data is not None:
         data_module = model_manager.get_data_module(
             setup_data=setup_data,
+            reward_options=reward_options,
             reader_options=reader_options,
             resource_options=resource_options,
         )

--- a/reagent/workflow/training.py
+++ b/reagent/workflow/training.py
@@ -233,13 +233,10 @@ def train_workflow(
         normalization_data_map = data_module.get_normalization_data_map()
 
     warmstart_input_path = warmstart_path or None
-    model_manager.initialize_trainer(
+    trainer_module = model_manager.build_trainer(
         use_gpu=use_gpu,
-        # pyre-fixme[6]: Expected `RewardOptions` for 2nd param but got
-        #  `Optional[RewardOptions]`.
         reward_options=reward_options,
         normalization_data_map=normalization_data_map,
-        warmstart_path=warmstart_input_path,
     )
 
     if not reader_options:
@@ -249,7 +246,8 @@ def train_workflow(
         resource_options = ResourceOptions()
 
     with summary_writer_context(writer):
-        train_output = model_manager.train(
+        train_output, lightning_trainer = model_manager.train(
+            trainer_module,
             train_dataset,
             eval_dataset,
             None,
@@ -257,11 +255,12 @@ def train_workflow(
             num_epochs,
             reader_options,
             resource_options,
+            checkpoint_path=warmstart_input_path,
         )
 
     output_paths = {}
     for module_name, serving_module in model_manager.build_serving_modules(
-        normalization_data_map
+        trainer_module, normalization_data_map
     ).items():
         torchscript_output_path = f"{model_manager.__class__.__name__}_{module_name}_{round(time.time())}.torchscript"
         torch.jit.save(serving_module, torchscript_output_path)

--- a/reagent/workflow/training.py
+++ b/reagent/workflow/training.py
@@ -229,9 +229,7 @@ def train_workflow(
 
     if normalization_data_map is None:
         assert data_module is not None
-        normalization_data_map = data_module.get_normalization_data_map(
-            model_manager.required_normalization_keys
-        )
+        normalization_data_map = data_module.get_normalization_data_map()
 
     warmstart_input_path = warmstart_path or None
     model_manager.initialize_trainer(

--- a/reagent/workflow/training.py
+++ b/reagent/workflow/training.py
@@ -261,7 +261,9 @@ def train_workflow(
         )
 
     output_paths = {}
-    for module_name, serving_module in model_manager.build_serving_modules().items():
+    for module_name, serving_module in model_manager.build_serving_modules(
+        normalization_data_map
+    ).items():
         torchscript_output_path = f"{model_manager.__class__.__name__}_{module_name}_{round(time.time())}.torchscript"
         torch.jit.save(serving_module, torchscript_output_path)
         logger.info(f"Saved {module_name} to {torchscript_output_path}")


### PR DESCRIPTION
Summary:
- Remove `initialize_trainer()`
- Implement `train()` on ModelManager base class; remove all the duplicates
- Make `build_serving_module[s]()` takes the trainer module so it can extract whatever nets in the trainer module
- `ModelManager.train()` now returns `Tuple[RLTrainingOutput, pl.Trainer]` so that `_lightning_trainer` member can be deleted

Differential Revision: D29258016

