### PR TITLE
Add missing init to synthetic reward to fix failing import

### DIFF
--- a/reagent/prediction/synthetic_reward/__init__.py
+++ b/reagent/prediction/synthetic_reward/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.


### PR DESCRIPTION
I found I was unable to run offline batch RL due to a failed import from the synthetic_reward folder, which was caused by a missing init file. Adding the file.  (After adding the file + rebuilding, the offline batch RL commands succeeded)