### PR TITLE
Add missing __init__.py to fix importing from synthetic reward

### DIFF
--- a/reagent/prediction/synthetic_reward/__init__.py
+++ b/reagent/prediction/synthetic_reward/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.


### PR DESCRIPTION
Summary: Offline Batch RL runs were failing on import error, which arose from missing init.py file

Reviewed By: czxttkl

Differential Revision: D29284160

