### PR TITLE
Migrate Seq2slate to PyTorch Lightning

### DIFF
--- a/reagent/test/ranking/seq2slate_utils.py
+++ b/reagent/test/ranking/seq2slate_utils.py
@@ -3,6 +3,7 @@ import math
 import tempfile
 from itertools import permutations
 
+import pytorch_lightning as pl
 import reagent.core.types as rlt
 import torch
 import torch.nn as nn
@@ -14,6 +15,7 @@ from reagent.models.seq2slate import Seq2SlateMode, Seq2SlateTransformerNet
 from reagent.optimizer.union import Optimizer__Union
 from reagent.training.ranking.seq2slate_sim_trainer import Seq2SlateSimulationTrainer
 from reagent.training.ranking.seq2slate_trainer import Seq2SlateTrainer
+from torch.utils.data import DataLoader
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +34,39 @@ class TSPRewardModel(nn.Module):
         return -reward
 
 
+def post_preprocess_batch(seq2slate_net, candidate_num, batch, device, epoch):
+    model_propensity, model_action, reward = rank_on_policy_and_eval(
+        seq2slate_net, batch, candidate_num, greedy=False
+    )
+    batch = rlt.PreprocessedRankingInput.from_input(
+        state=batch.state.float_features,
+        candidates=batch.src_seq.float_features,
+        device=device,
+        action=model_action,
+        logged_propensities=model_propensity,
+        # negate because we want to minimize
+        slate_reward=-reward,
+    )
+    logger.info(f"Epoch {epoch} mean on_policy reward: {torch.mean(reward)}")
+    logger.info(f"Epoch {epoch} mean model_propensity: {torch.mean(model_propensity)}")
+    return batch
+
+
+class Seq2SlateOnPolicyTrainer(Seq2SlateTrainer):
+    def on_train_batch_start(self, batch, batch_idx, dataloader_idx):
+        new_batch = post_preprocess_batch(
+            self.seq2slate_net,
+            self.seq2slate_net.max_src_seq_len,
+            batch,
+            batch.state.float_features.device,
+            self.current_epoch,
+        )
+        for attr in dir(new_batch):
+            if not callable(getattr(new_batch, attr)) and not attr.startswith("__"):
+                setattr(batch, attr, getattr(new_batch, attr))
+        super().on_train_batch_start(batch, batch_idx, dataloader_idx)
+
+
 def create_trainer(
     seq2slate_net,
     learning_method,
@@ -40,12 +75,11 @@ def create_trainer(
     policy_gradient_interval,
     device,
 ):
-    use_gpu = False if device == torch.device("cpu") else True
     if learning_method == ON_POLICY:
         seq2slate_params = Seq2SlateParameters(
             on_policy=True, learning_method=LearningMethod.REINFORCEMENT_LEARNING
         )
-        trainer_cls = Seq2SlateTrainer
+        trainer_cls = Seq2SlateOnPolicyTrainer
     elif learning_method == OFF_POLICY:
         seq2slate_params = Seq2SlateParameters(
             on_policy=False,
@@ -69,10 +103,8 @@ def create_trainer(
 
     param_dict = {
         "seq2slate_net": seq2slate_net,
-        "minibatch_size": batch_size,
-        "parameters": seq2slate_params,
+        "params": seq2slate_params,
         "policy_optimizer": Optimizer__Union.default(lr=learning_rate),
-        "use_gpu": use_gpu,
         "print_interval": 1,
         "policy_gradient_interval": policy_gradient_interval,
     }
@@ -104,29 +136,6 @@ def create_seq2slate_net(
         ).to(device)
     else:
         raise NotImplementedError(f"unknown model type {model_str}")
-
-
-def post_preprocess_batch(
-    learning_method, seq2slate_net, candidate_num, batch, device, epoch
-):
-    if learning_method == ON_POLICY:
-        model_propensity, model_action, reward = rank_on_policy_and_eval(
-            seq2slate_net, batch, candidate_num, greedy=False
-        )
-        batch = rlt.PreprocessedRankingInput.from_input(
-            state=batch.state.float_features,
-            candidates=batch.src_seq.float_features,
-            device=device,
-            action=model_action,
-            logged_propensities=model_propensity,
-            # negate because we want to minimize
-            slate_reward=-reward,
-        )
-        logger.info(f"Epoch {epoch} mean on_policy reward: {torch.mean(reward)}")
-        logger.info(
-            f"Epoch {epoch} mean model_propensity: {torch.mean(model_propensity)}"
-        )
-    return batch
 
 
 FIX_CANDIDATES = None
@@ -288,6 +297,8 @@ def run_seq2slate_tsp(
     policy_gradient_interval,
     device,
 ):
+    pl.seed_everything(0)
+
     candidate_dim = 2
     eval_sample_size = 1
 
@@ -321,21 +332,11 @@ def run_seq2slate_tsp(
         device,
     )
 
-    for e in range(epochs + 1):
-        # Only evaluate in the first epoch
-        if e > 0:
-            # training
-            for batch in train_batches:
-                batch = post_preprocess_batch(
-                    learning_method, seq2slate_net, candidate_num, batch, device, e
-                )
-                trainer.train(batch)
-
-        # evaluation
+    def evaluate():
         best_test_reward = torch.full((batch_size,), 1e9).to(device)
         for _ in range(eval_sample_size):
             model_propensities, _, reward = rank_on_policy_and_eval(
-                seq2slate_net, test_batch, candidate_num, greedy=True
+                seq2slate_net.to(device), test_batch, candidate_num, greedy=True
             )
             best_test_reward = torch.where(
                 reward < best_test_reward, reward, best_test_reward
@@ -347,10 +348,22 @@ def run_seq2slate_tsp(
         )
         if torch.any(torch.isnan(model_propensities)):
             raise Exception("Model propensities contain NaNs")
-        if (
-            torch.mean(best_test_reward)
-            < best_test_possible_reward * expect_reward_threshold
-        ):
-            return
+        ratio = torch.mean(best_test_reward) / best_test_possible_reward
+        return ratio < expect_reward_threshold, ratio
 
-    raise AssertionError("Test failed because it did not reach expected test reward")
+    evaluate()
+
+    training_data = DataLoader(train_batches, collate_fn=lambda x: x[0])
+    pl_trainer = pl.Trainer(
+        max_epochs=epochs,
+        gpus=None if device == torch.device("cpu") else 1,
+        logger=False,
+    )
+    pl_trainer.fit(trainer, training_data)
+
+    result, ratio = evaluate()
+
+    assert result, (
+        f"Test failed because it did not reach expected test reward, "
+        f"{ratio} > {expect_reward_threshold}."
+    )

--- a/reagent/test/ranking/test_seq2slate_on_policy.py
+++ b/reagent/test/ranking/test_seq2slate_on_policy.py
@@ -318,7 +318,7 @@ class TestSeq2SlateOnPolicy(unittest.TestCase):
         batch_size = 4096
         epochs = 1
         num_batches = 50
-        expect_reward_threshold = 1.02
+        expect_reward_threshold = 1.12
         hidden_size = 32
         num_candidates = 6
         diverse_input = False
@@ -350,7 +350,7 @@ class TestSeq2SlateOnPolicy(unittest.TestCase):
         batch_size = 4096
         epochs = 3
         num_batches = 300
-        expect_reward_threshold = 1.03
+        expect_reward_threshold = 1.05
         hidden_size = 32
         num_candidates = 6
         diverse_input = True

--- a/reagent/test/ranking/test_seq2slate_simulation.py
+++ b/reagent/test/ranking/test_seq2slate_simulation.py
@@ -25,7 +25,7 @@ class TestSeq2SlateSimulation(unittest.TestCase):
         batch_size = 4096
         epochs = 1
         num_batches = 50
-        expect_reward_threshold = 1.02
+        expect_reward_threshold = 1.12
         hidden_size = 32
         num_candidates = 6
         diverse_input = False

--- a/reagent/training/ranking/seq2slate_attn_trainer.py
+++ b/reagent/training/ranking/seq2slate_attn_trainer.py
@@ -28,7 +28,6 @@ class Seq2SlatePairwiseAttnTrainer(Trainer):
     def __init__(
         self,
         seq2slate_net: Seq2SlateTransformerNet,
-        minibatch_size: int = 1024,
         loss_reporter=None,
         use_gpu: bool = False,
         policy_optimizer: Optimizer__Union = field(  # noqa: B008
@@ -38,7 +37,6 @@ class Seq2SlatePairwiseAttnTrainer(Trainer):
         self.loss_reporter = loss_reporter
         self.use_gpu = use_gpu
         self.seq2slate_net = seq2slate_net
-        self.minibatch_size = minibatch_size
         self.minibatch = 0
         self.optimizer = policy_optimizer.make_optimizer_scheduler(
             self.seq2slate_net.parameters()

--- a/reagent/training/ranking/seq2slate_tf_trainer.py
+++ b/reagent/training/ranking/seq2slate_tf_trainer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 import logging
+from typing import List, Optional, Tuple
 
 import reagent.core.types as rlt
 import torch
@@ -8,16 +9,17 @@ import torch.nn as nn
 import torch.nn.functional as F
 from reagent.core.dataclasses import field
 from reagent.core.parameters import Seq2SlateParameters
+from reagent.evaluation.evaluation_data_page import EvaluationDataPage
 from reagent.model_utils.seq2slate_utils import Seq2SlateMode
 from reagent.models.seq2slate import Seq2SlateTransformerNet
 from reagent.optimizer.union import Optimizer__Union
-from reagent.training.trainer import Trainer
+from reagent.training.reagent_lightning_module import ReAgentLightningModule
 
 
 logger = logging.getLogger(__name__)
 
 
-class Seq2SlateTeacherForcingTrainer(Trainer):
+class Seq2SlateTeacherForcingTrainer(ReAgentLightningModule):
     """
     Seq2Slate learned in a teach-forcing fashion (only used if the
     the ground-truth sequences are available)
@@ -26,57 +28,65 @@ class Seq2SlateTeacherForcingTrainer(Trainer):
     def __init__(
         self,
         seq2slate_net: Seq2SlateTransformerNet,
-        parameters: Seq2SlateParameters,
-        minibatch_size: int,
-        use_gpu: bool = False,
+        params: Seq2SlateParameters,
         policy_optimizer: Optimizer__Union = field(  # noqa: B008
             default_factory=Optimizer__Union.default
         ),
         policy_gradient_interval: int = 1,
         print_interval: int = 100,
+        calc_cpe: bool = False,
+        reward_network: Optional[nn.Module] = None,
     ) -> None:
-        self.parameters = parameters
-        self.use_gpu = use_gpu
+        super().__init__()
+        self.params = params
         self.policy_gradient_interval = policy_gradient_interval
         self.print_interval = print_interval
         self.seq2slate_net = seq2slate_net
-        self.minibatch_size = minibatch_size
-        self.minibatch = 0
-        self.optimizer = policy_optimizer.make_optimizer_scheduler(
-            self.seq2slate_net.parameters()
-        )["optimizer"]
-        self.optimizer.zero_grad()
+        self.policy_optimizer = policy_optimizer
         self.kl_div_loss = nn.KLDivLoss(reduction="batchmean")
 
-    def warm_start_components(self):
-        components = ["seq2slate_net"]
-        return components
+        # use manual optimization to get more flexibility
+        self.automatic_optimization = False
 
-    def train(self, training_batch: rlt.PreprocessedRankingInput):
-        assert type(training_batch) is rlt.PreprocessedRankingInput
-        self.minibatch += 1
+        assert not calc_cpe or reward_network is not None
+        self.calc_cpe = calc_cpe
+        self.reward_network = reward_network
+
+    def configure_optimizers(self):
+        optimizers = []
+        optimizers.append(
+            self.policy_optimizer.make_optimizer_scheduler(
+                self.seq2slate_net.parameters()
+            )
+        )
+        return optimizers
+
+    # pyre-fixme [14]: overrides method defined in `ReAgentLightningModule` inconsistently
+    def training_step(self, batch: rlt.PreprocessedRankingInput, batch_idx: int):
+        assert type(batch) is rlt.PreprocessedRankingInput
 
         log_probs = self.seq2slate_net(
-            training_batch, mode=Seq2SlateMode.PER_SYMBOL_LOG_PROB_DIST_MODE
+            batch, mode=Seq2SlateMode.PER_SYMBOL_LOG_PROB_DIST_MODE
         ).log_probs
         assert log_probs.requires_grad
 
-        assert training_batch.optim_tgt_out_idx is not None
+        assert batch.optim_tgt_out_idx is not None
         # pyre-fixme[6]: Expected `Tensor` for 1st param but got
         #  `Optional[torch.Tensor]`.
-        labels = self._transform_label(training_batch.optim_tgt_out_idx)
+        labels = self._transform_label(batch.optim_tgt_out_idx)
         assert not labels.requires_grad
         loss = self.kl_div_loss(log_probs, labels)
 
-        loss.backward()
-        if self.minibatch % self.policy_gradient_interval == 0:
-            self.optimizer.step()
-            self.optimizer.zero_grad()
+        self.manual_backward(loss)
+        if (self.all_batches_processed + 1) % self.policy_gradient_interval == 0:
+            opt = self.optimizers()[0]
+            opt.step()
+            opt.zero_grad()
 
         loss = loss.detach().cpu().numpy()
         log_probs = log_probs.detach()
-        if self.minibatch % self.print_interval == 0:
-            logger.info(f"{self.minibatch} batch: loss={loss}")
+        if (self.all_batches_processed + 1) % self.print_interval == 0:
+            logger.info(f"{self.all_batches_processed + 1} batch: loss={loss}")
 
         return log_probs, loss
 
@@ -84,3 +94,63 @@ class Seq2SlateTeacherForcingTrainer(Trainer):
         label_size = self.seq2slate_net.max_src_seq_len + 2
         label = F.one_hot(optim_tgt_out_idx, label_size)
         return label.float()
+
+    # pyre-ignore inconsistent override because lightning doesn't use types
+    def validation_step(self, batch: rlt.PreprocessedRankingInput, batch_idx: int):
+        seq2slate_net = self.seq2slate_net
+
+        assert seq2slate_net.training is False
+
+        logged_slate_rank_prob = torch.exp(
+            seq2slate_net(batch, mode=Seq2SlateMode.PER_SEQ_LOG_PROB_MODE)
+            .log_probs.detach()
+            .flatten()
+            .cpu()
+        )
+
+        ranked_slate_output = seq2slate_net(batch, Seq2SlateMode.RANK_MODE, greedy=True)
+        ranked_slate_rank_prob = ranked_slate_output.ranked_per_seq_probs.cpu()
+
+        self.reporter.log(
+            logged_slate_rank_probs=logged_slate_rank_prob,
+            ranked_slate_rank_probs=ranked_slate_rank_prob,
+        )
+
+        if not self.calc_cpe:
+            return
+
+        edp_g = EvaluationDataPage.create_from_tensors_seq2slate(
+            seq2slate_net,
+            self.reward_network,
+            batch,
+            eval_greedy=True,
+        )
+
+        edp_ng = EvaluationDataPage.create_from_tensors_seq2slate(
+            seq2slate_net,
+            self.reward_network,
+            batch,
+            eval_greedy=False,
+        )
+
+        return edp_g, edp_ng
+
+    # pyre-fixme[14]: Inconsistent override
+    def validation_epoch_end(
+        self, outputs: Optional[List[Tuple[EvaluationDataPage, EvaluationDataPage]]]
+    ):
+        if self.calc_cpe:
+            assert outputs is not None
+            eval_data_pages_g, eval_data_pages_ng = None, None
+            for edp_g, edp_ng in outputs:
+                if eval_data_pages_g is None and eval_data_pages_ng is None:
+                    eval_data_pages_g = edp_g
+                    eval_data_pages_ng = edp_ng
+                else:
+                    # pyre-fixme[16]: `Optional` has no attribute `append`
+                    eval_data_pages_g.append(edp_g)
+                    eval_data_pages_ng.append(edp_ng)
+            self.reporter.log(
+                eval_data_pages_g=eval_data_pages_g,
+                eval_data_pages_ng=eval_data_pages_ng,
+            )

--- a/reagent/training/ranking/seq2slate_trainer.py
+++ b/reagent/training/ranking/seq2slate_trainer.py
@@ -1,43 +1,34 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 import logging
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import reagent.core.types as rlt
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 from reagent.core.dataclasses import field
 from reagent.core.parameters import Seq2SlateParameters
-from reagent.core.tracker import observable
+from reagent.evaluation.evaluation_data_page import EvaluationDataPage
 from reagent.model_utils.seq2slate_utils import Seq2SlateMode
 from reagent.models.seq2slate import BaselineNet, Seq2SlateTransformerNet
 from reagent.optimizer.union import Optimizer__Union
 from reagent.training.ranking.helper import ips_clamp
-from reagent.training.trainer import Trainer
+from reagent.training.reagent_lightning_module import ReAgentLightningModule
 
 
 logger = logging.getLogger(__name__)
 
 
-@observable(
-    train_ips_score=torch.Tensor,
-    train_clamped_ips_score=torch.Tensor,
-    train_baseline_loss=torch.Tensor,
-    train_logged_slate_rank_probs=torch.Tensor,
-    train_ips_ratio=torch.Tensor,
-    train_clamped_ips_ratio=torch.Tensor,
-    train_advantages=torch.Tensor,
-)
-class Seq2SlateTrainer(Trainer):
+class Seq2SlateTrainer(ReAgentLightningModule):
     def __init__(
         self,
         seq2slate_net: Seq2SlateTransformerNet,
-        minibatch_size: int = 1024,
-        parameters: Seq2SlateParameters = field(  # noqa: B008
+        params: Seq2SlateParameters = field(  # noqa: B008
             default_factory=Seq2SlateParameters
         ),
         baseline_net: Optional[BaselineNet] = None,
         baseline_warmup_num_batches: int = 0,
-        use_gpu: bool = False,
         policy_optimizer: Optimizer__Union = field(  # noqa: B008
             default_factory=Optimizer__Union.default
         ),
@@ -46,34 +37,41 @@ class Seq2SlateTrainer(Trainer):
         ),
         policy_gradient_interval: int = 1,
         print_interval: int = 100,
+        calc_cpe: bool = False,
+        reward_network: Optional[nn.Module] = None,
     ) -> None:
+        super().__init__()
         self.seq2slate_net = seq2slate_net
-        self.parameters = parameters
-        self.use_gpu = use_gpu
+        self.params = params
         self.policy_gradient_interval = policy_gradient_interval
         self.print_interval = print_interval
-
-        self.minibatch_size = minibatch_size
-        self.minibatch = 0
 
         self.baseline_net = baseline_net
         self.baseline_warmup_num_batches = baseline_warmup_num_batches
 
-        self.rl_opt = policy_optimizer.make_optimizer_scheduler(
-            self.seq2slate_net.parameters()
-        )["optimizer"]
-        self.rl_opt.zero_grad()
+        self.rl_opt = policy_optimizer
         if self.baseline_net:
-            self.baseline_opt = baseline_optimizer.make_optimizer_scheduler(
-                # pyre-fixme[16]: `Optional` has no attribute `parameters`.
-                self.baseline_net.parameters()
-            )["optimizer"]
+            self.baseline_opt = baseline_optimizer
 
-    def warm_start_components(self):
-        components = ["seq2slate_net"]
+        # use manual optimization to get more flexibility
+        self.automatic_optimization = False
+
+        assert not calc_cpe or reward_network is not None
+        self.calc_cpe = calc_cpe
+        self.reward_network = reward_network
+
+    def configure_optimizers(self):
+        optimizers = []
+        optimizers.append(
+            self.rl_opt.make_optimizer_scheduler(self.seq2slate_net.parameters())
+        )
         if self.baseline_net:
-            components.append("baseline_net")
-        return components
+            optimizers.append(
+                self.baseline_opt.make_optimizer_scheduler(
+                    self.baseline_net.parameters()
+                )
+            )
+        return optimizers
 
     def _compute_impt_smpl(
         self, model_propensities, logged_propensities
@@ -86,37 +84,43 @@ class Seq2SlateTrainer(Trainer):
         ), f"{model_propensities.shape} {logged_propensities.shape}"
 
         impt_smpl = model_propensities / logged_propensities
-        clamped_impt_smpl = ips_clamp(impt_smpl, self.parameters.ips_clamp)
+        clamped_impt_smpl = ips_clamp(impt_smpl, self.params.ips_clamp)
         return impt_smpl, clamped_impt_smpl
 
-    def train(self, training_batch: rlt.PreprocessedRankingInput):
-        assert type(training_batch) is rlt.PreprocessedRankingInput
-        self.minibatch += 1
+    # pyre-fixme [14]: overrides method defined in `ReAgentLightningModule` inconsistently
+    def training_step(self, batch: rlt.PreprocessedRankingInput, batch_idx: int):
+        assert type(batch) is rlt.PreprocessedRankingInput
 
-        batch_size = training_batch.state.float_features.shape[0]
-        device = torch.device("cuda") if self.use_gpu else torch.device("cpu")
+        batch_size = batch.state.float_features.shape[0]
 
-        reward = training_batch.slate_reward
-        batch_size = training_batch.state.float_features.shape[0]
+        reward = batch.slate_reward
         assert reward is not None
+
+        optimizers = self.optimizers()
+        if self.baseline_net:
+            assert len(optimizers) == 2
+            baseline_opt = optimizers[1]
+        else:
+            assert len(optimizers) == 1
+        rl_opt = optimizers[0]
 
         if self.baseline_net:
             # Train baseline
             # pyre-fixme[29]: `Optional[BaselineNet]` is not a function.
-            b = self.baseline_net(training_batch)
+            b = self.baseline_net(batch)
             baseline_loss = 1.0 / batch_size * torch.sum((b - reward) ** 2)
-            self.baseline_opt.zero_grad()
-            baseline_loss.backward()
-            self.baseline_opt.step()
+            baseline_opt.zero_grad()
+            self.manual_backward(baseline_loss)
+            baseline_opt.step()
         else:
-            b = torch.zeros_like(reward, device=device)
-            baseline_loss = torch.zeros(1, device=device)
+            b = torch.zeros_like(reward)
+            baseline_loss = torch.zeros(1)
 
         # Train Seq2Slate using REINFORCE
         # log probs of tgt seqs
         model_propensities = torch.exp(
             self.seq2slate_net(
-                training_batch, mode=Seq2SlateMode.PER_SEQ_LOG_PROB_MODE
+                batch, mode=Seq2SlateMode.PER_SEQ_LOG_PROB_MODE
             ).log_probs
         )
         b = b.detach()
@@ -125,7 +129,7 @@ class Seq2SlateTrainer(Trainer):
         ), f"{b.shape} {reward.shape} {model_propensities.shape}"
 
         impt_smpl, clamped_impt_smpl = self._compute_impt_smpl(
-            model_propensities, training_batch.tgt_out_probs
+            model_propensities, batch.tgt_out_probs
         )
         assert (
             impt_smpl.shape == clamped_impt_smpl.shape == reward.shape
@@ -134,7 +138,7 @@ class Seq2SlateTrainer(Trainer):
         assert (
             not reward.requires_grad
             # pyre-fixme[16]: `Optional` has no attribute `requires_grad`.
-            and not training_batch.tgt_out_probs.requires_grad
+            and not batch.tgt_out_probs.requires_grad
             and impt_smpl.requires_grad
             and clamped_impt_smpl.requires_grad
             and not b.requires_grad
@@ -150,12 +154,12 @@ class Seq2SlateTrainer(Trainer):
         # 3. the last policy gradient was performed policy_gradient_interval minibatches ago
         if (
             self.baseline_net is None
-            or self.minibatch >= self.baseline_warmup_num_batches
+            or (self.all_batches_processed + 1) >= self.baseline_warmup_num_batches
         ):
-            obj_loss.backward()
-            if self.minibatch % self.policy_gradient_interval == 0:
-                self.rl_opt.step()
-                self.rl_opt.zero_grad()
+            self.manual_backward(obj_loss)
+            if (self.all_batches_processed + 1) % self.policy_gradient_interval == 0:
+                rl_opt.step()
+                rl_opt.zero_grad()
         else:
             logger.info("Not update RL model because now is baseline warmup phase")
 
@@ -167,22 +171,20 @@ class Seq2SlateTrainer(Trainer):
         advantage = (reward - b).detach().cpu().numpy()
         logged_slate_rank_probs = model_propensities.detach().cpu().numpy()
 
-        if self.minibatch % self.print_interval == 0:
+        if (self.all_batches_processed + 1) % self.print_interval == 0:
             logger.info(
                 "{} batch: ips_loss={}, clamped_ips_loss={}, baseline_loss={}, max_ips={}, mean_ips={}, grad_update={}".format(
-                    self.minibatch,
+                    self.all_batches_processed + 1,
                     ips_loss,
                     clamped_ips_loss,
                     baseline_loss,
                     torch.max(impt_smpl),
                     torch.mean(impt_smpl),
-                    self.minibatch % self.policy_gradient_interval == 0,
+                    (self.all_batches_processed + 1) % self.policy_gradient_interval
+                    == 0,
                 )
             )
-        # See RankingTrainingPageHandler.finish() function in page_handler.py
-        # pyre-fixme[16]: `Seq2SlateTrainer` has no attribute
-        #  `notify_observers`.
-        self.notify_observers(
+        self.reporter.log(
             train_ips_score=torch.tensor(ips_loss).reshape(1),
             train_clamped_ips_score=torch.tensor(clamped_ips_loss).reshape(1),
             train_baseline_loss=torch.tensor(baseline_loss).reshape(1),
@@ -191,3 +193,83 @@ class Seq2SlateTrainer(Trainer):
             train_clamped_ips_ratio=clamped_impt_smpl,
             train_advantages=advantage,
         )
+
+    # pyre-ignore inconsistent override because lightning doesn't use types
+    def validation_step(self, batch: rlt.PreprocessedRankingInput, batch_idx: int):
+        seq2slate_net = self.seq2slate_net
+
+        assert seq2slate_net.training is False
+
+        logged_slate_rank_prob = torch.exp(
+            seq2slate_net(batch, mode=Seq2SlateMode.PER_SEQ_LOG_PROB_MODE)
+            .log_probs.detach()
+            .flatten()
+            .cpu()
+        )
+
+        eval_baseline_loss = torch.tensor([0.0]).reshape(1)
+        if self.baseline_net:
+            baseline_net = self.baseline_net
+            # pyre-fixme[29]: `Optional[reagent.models.seq2slate.BaselineNet]` is
+            #  not a function.
+            b = baseline_net(batch).detach()
+            eval_baseline_loss = F.mse_loss(b, batch.slate_reward).cpu().reshape(1)
+        else:
+            b = torch.zeros_like(batch.slate_reward)
+
+        eval_advantage = (
+            # pyre-fixme[58]: `-` is not supported for operand types
+            #  `Optional[torch.Tensor]` and `Any`.
+            (batch.slate_reward - b)
+            .flatten()
+            .cpu()
+        )
+
+        ranked_slate_output = seq2slate_net(batch, Seq2SlateMode.RANK_MODE, greedy=True)
+        ranked_slate_rank_prob = ranked_slate_output.ranked_per_seq_probs.cpu()
+
+        self.reporter.log(
+            eval_baseline_loss=eval_baseline_loss,
+            eval_advantages=eval_advantage,
+            logged_slate_rank_probs=logged_slate_rank_prob,
+            ranked_slate_rank_probs=ranked_slate_rank_prob,
+        )
+
+        if not self.calc_cpe:
+            return
+
+        edp_g = EvaluationDataPage.create_from_tensors_seq2slate(
+            seq2slate_net,
+            self.reward_network,
+            batch,
+            eval_greedy=True,
+        )
+
+        edp_ng = EvaluationDataPage.create_from_tensors_seq2slate(
+            seq2slate_net,
+            self.reward_network,
+            batch,
+            eval_greedy=False,
+        )
+
+        return edp_g, edp_ng
+
+    # pyre-fixme[14]: Inconsistent override
+    def validation_epoch_end(
+        self, outputs: Optional[List[Tuple[EvaluationDataPage, EvaluationDataPage]]]
+    ):
+        if self.calc_cpe:
+            assert outputs is not None
+            eval_data_pages_g, eval_data_pages_ng = None, None
+            for edp_g, edp_ng in outputs:
+                if eval_data_pages_g is None and eval_data_pages_ng is None:
+                    eval_data_pages_g = edp_g
+                    eval_data_pages_ng = edp_ng
+                else:
+                    # pyre-fixme[16]: `Optional` has no attribute `append`
+                    eval_data_pages_g.append(edp_g)
+                    eval_data_pages_ng.append(edp_ng)
+            self.reporter.log(
+                eval_data_pages_g=eval_data_pages_g,
+                eval_data_pages_ng=eval_data_pages_ng,
+            )


### PR DESCRIPTION
Summary: Migrate the regular seq2slate to PyTorch Lightning, which includes one model manager `Seq2SlateTransformer` and three trainers `Seq2SlateTrainer`, `Seq2SlateSimulationTrainer` and `Seq2SlateTeacherForcingTrainer`. Manual optimization (https://pytorch-lightning.readthedocs.io/en/latest/common/optimizers.html#manual-optimization) is used to handle the sophisticated usage of optimizers during training.

Differential Revision: D29436608

