### PR TITLE
Implementation of a transformer-based return decomposition model

### DIFF
--- a/reagent/models/synthetic_reward.py
+++ b/reagent/models/synthetic_reward.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 import logging
+import math
 from typing import List
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from reagent.core import parameters as rlp
 from reagent.core import types as rlt
 from reagent.models import convolutional_network
@@ -12,8 +14,16 @@ from reagent.models import fully_connected_network
 from reagent.models.base import ModelBase
 from reagent.models.fully_connected_network import ACTIVATION_MAP
 
-
 logger = logging.getLogger(__name__)
+
+
+def _get_activation_fn(activation):
+    if activation == "relu":
+        return F.relu
+    elif activation == "gelu":
+        return F.gelu
+
+    raise RuntimeError("activation should be relu/gelu, not {}".format(activation))
 
 
 class Concat(nn.Module):
@@ -32,6 +42,137 @@ class SequentialMultiArguments(nn.Sequential):
             else:
                 inputs = module(inputs)
         return inputs
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, d_model=64, dim_feedforward=128):
+        super(ResidualBlock, self).__init__()
+        self.relu = nn.ReLU()
+        self.fc_residual = nn.Sequential(
+            nn.Linear(d_model, dim_feedforward),
+            nn.ReLU(),
+            nn.Linear(dim_feedforward, d_model),
+        )
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(x + self.fc_residual(x))
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, feature_dim=128, dropout=0.0, max_len=100):
+        """
+        This module injects some information about the relative or absolute position of the tokens in the sequence.
+        The generated positional encoding are concatenated together with the features.
+        Args: input dim
+        """
+        super(PositionalEncoding, self).__init__()
+        self.dropout = nn.Dropout(p=dropout)
+        pe = torch.zeros(max_len, feature_dim, requires_grad=False)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, feature_dim, 2).float() * (-math.log(10000.0) / feature_dim)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)  # max_len * feature_dim // 2
+        pe[:, 1::2] = torch.cos(position * div_term)
+        # pe dimension: (max_len, 1, feature_dim)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x):
+        # x dimension: (L, B, E)
+        # batch_size, seq_len, d_model
+        seq_len = x.shape[0]
+        pos_encoding = self.pe[:seq_len, :]
+        x = x + pos_encoding
+        return self.dropout(x)
+
+
+class PETransformerEncoderLayer(nn.Module):
+    """PETransformerEncoderLayer is made up of Positional Encoding (PE), residual connections, self-attn and feedforward network.
+    Major differences between this implementation and the pytorch official torch.nn.TransformerEncoderLayer are:
+    1. Augment input data with positional encoding. hat{x} = x + PE{x}
+    2. Two paralle residual blocks are applied to the raw input data (x) and encoded input data (hat{x}), respectively, i.e. z = Residual(x), hat{z} = Residual(hat{x})
+    3. Treat z as the Value input, and hat{z} as the Query and Key input to feed a self-attention block.
+
+    Main Args:
+        d_model: the number of expected features in the input (required).
+        nhead: the number of heads in the multiheadattention models (required).
+        dim_feedforward: the dimension of the feedforward network model (default=2048).
+        activation: the activation function of intermediate layer, relu or gelu (default=relu).
+        layer_norm_eps: the eps value in layer normalization components (default=1e-5).
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False``.
+        max_len: argument passed to the Positional Encoding module, see more details in the PositionalEncoding class.
+    """
+
+    __constants__ = ["batch_first"]
+
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.0,
+        activation="relu",
+        layer_norm_eps=1e-5,
+        max_len=100,
+        use_ff=True,
+        pos_weight=0.5,
+        batch_first=False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super(PETransformerEncoderLayer, self).__init__()
+        self.use_ff = use_ff
+        self.pos_weight = pos_weight
+        self.self_attn = nn.MultiheadAttention(
+            d_model, nhead, dropout=dropout, batch_first=batch_first, **factory_kwargs
+        )
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward, **factory_kwargs)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model, **factory_kwargs)
+
+        self.norm1 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+        self.norm2 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+
+        # Customized implementation: to map Query & Key, Value with different embeddings.
+        self.qk_residual = ResidualBlock(d_model, dim_feedforward)
+        self.v_residual = ResidualBlock(d_model, dim_feedforward)
+        self.pos_encoder = PositionalEncoding(d_model, dropout=dropout, max_len=max_len)
+
+        self.activation = _get_activation_fn(activation)
+
+    def __setstate__(self, state):
+        if "activation" not in state:
+            state["activation"] = F.relu
+        super(PETransformerEncoderLayer, self).__setstate__(state)
+
+    def forward(self, src, src_mask=None, src_key_padding_mask=None):
+        encoded_src = self.pos_encoder(src)
+        query = self.qk_residual(encoded_src)
+        # do not involve pos_encoding info into the value
+        src = self.v_residual(src)
+
+        src2 = self.self_attn(
+            query,  # query
+            query,  # key = query as the input
+            src,  # value
+            attn_mask=src_mask,
+            key_padding_mask=src_key_padding_mask,
+        )[0]
+        # add transformer related residual
+        src = src + self.dropout1(src2)
+        src = self.norm1(src)
+        # add another ff layer
+        src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
+        src = src + self.dropout2(src2)
+        src = self.norm2(src)
+        return src
 
 
 def ngram(input: torch.Tensor, context_size: int, ngram_padding: torch.Tensor):
@@ -308,4 +449,82 @@ class SequenceSyntheticRewardNet(nn.Module):
         output = self.fc_out(output)
         # output shape: batch_size, seq_len
         output = self.output_activation(output).squeeze(2).transpose(0, 1)
+        return output
+
+
+class TransformerSyntheticRewardNet(nn.Module):
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        d_model: int,
+        nhead: int = 2,
+        num_encoder_layers: int = 2,
+        dim_feedforward: int = 128,
+        dropout: float = 0.0,
+        activation: str = "relu",
+        last_layer_activation: str = "leaky_relu",
+        layer_norm_eps: float = 1e-5,
+        max_len: int = 10,
+    ):
+        """
+        Decompose rewards at the last step to individual steps using transformer modules.
+
+        Args:
+            nhead: the number of heads in the multiheadattention models (default=8).
+            num_encoder_layers: the number of sub-encoder-layers in the encoder (default=6).
+            dim_feedforward: the dimension of the feedforward network model (default=2048).
+            dropout: the dropout value (default=0.1).
+            activation: the activation function of encoder/decoder intermediate layer, relu or gelu (default=relu).
+            layer_norm_eps: the eps value in layer normalization components (default=1e-5).
+        """
+        super().__init__()
+
+        self.state_dim = state_dim
+        self.action_dim = action_dim
+        # d_model: dimension of transformer input
+        self.d_model = d_model
+        self.nhead = nhead
+        self.num_encoder_layers = num_encoder_layers
+        self.dim_feedforward = dim_feedforward
+        self.dropout = dropout
+        self.activation = activation
+        self.layer_norm_eps = layer_norm_eps
+        self.max_len = max_len
+
+        # map input features to higher latent space before sending to transformer
+        self.fc_in = nn.Sequential(
+            nn.Linear(self.state_dim + self.action_dim, self.d_model),
+            nn.ReLU(),
+        )
+
+        # use transformer encoder to get reward logits for each step
+        encoder_layer = PETransformerEncoderLayer(
+            self.d_model,
+            nhead,
+            dim_feedforward,
+            dropout,
+            activation,
+            layer_norm_eps,
+            max_len=self.max_len,
+            batch_first=False,
+        )
+        self.transformer = nn.TransformerEncoder(
+            encoder_layer,
+            num_encoder_layers,
+        )
+        self.fc_out = nn.Linear(self.d_model, 1)
+        self.output_activation = ACTIVATION_MAP[last_layer_activation]()
+
+    def forward(self, state: torch.Tensor, action: torch.Tensor):
+        # shape: seq_len (L), batch_size (B), state_dim + action_dim
+        cat_input = torch.cat((state, action), dim=-1)
+        # latent_input shape: (L,B,E)
+        latent_input = self.fc_in(cat_input)
+        # output shape: (L, B, E)
+        output = self.transformer(latent_input)
+        output = self.fc_out(output)
+        # output shape: seq_len, batch_size, 1
+        output = self.output_activation(output).squeeze(2).transpose(0, 1)
+        # output shape: batch_size, seq_len
         return output

--- a/reagent/net_builder/synthetic_reward/transformer_synthetic_reward.py
+++ b/reagent/net_builder/synthetic_reward/transformer_synthetic_reward.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from typing import List, Optional
+
+from reagent.core.dataclasses import dataclass
+from reagent.core.parameters import NormalizationData, param_hash
+from reagent.models.base import ModelBase
+from reagent.models.synthetic_reward import (
+    TransformerSyntheticRewardNet,
+    SyntheticRewardNet,
+)
+from reagent.net_builder.synthetic_reward_net_builder import SyntheticRewardNetBuilder
+from reagent.preprocessing.normalization import get_num_output_features
+
+
+@dataclass
+class TransformerSyntheticReward(SyntheticRewardNetBuilder):
+    __hash__ = param_hash
+
+    nhead: int = 1
+    d_model: int = 128
+    num_encoder_layers: int = 2
+    dim_feedforward: int = 128
+    dropout: float = 0.0
+    activation: str = "relu"
+    last_layer_activation: str = "leaky_relu"
+    layer_norm_eps: float = 1e-5
+    max_len: int = 10
+
+    def build_synthetic_reward_network(
+        self,
+        state_normalization_data: NormalizationData,
+        action_normalization_data: Optional[NormalizationData] = None,
+        discrete_action_names: Optional[List[str]] = None,
+    ) -> ModelBase:
+        state_dim = get_num_output_features(
+            state_normalization_data.dense_normalization_parameters
+        )
+        if not discrete_action_names:
+            assert action_normalization_data is not None
+            action_dim = get_num_output_features(
+                action_normalization_data.dense_normalization_parameters
+            )
+        else:
+            action_dim = len(discrete_action_names)
+
+        net = TransformerSyntheticRewardNet(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            d_model=self.d_model,
+            nhead=self.nhead,
+            num_encoder_layers=self.num_encoder_layers,
+            dim_feedforward=self.dim_feedforward,
+            dropout=self.dropout,
+            activation=self.activation,
+            last_layer_activation=self.last_layer_activation,
+            layer_norm_eps=self.layer_norm_eps,
+            max_len=self.max_len,
+        )
+        return SyntheticRewardNet(net=net)

--- a/reagent/net_builder/unions.py
+++ b/reagent/net_builder/unions.py
@@ -38,6 +38,9 @@ from .synthetic_reward.sequence_synthetic_reward import (
 from .synthetic_reward.single_step_synthetic_reward import (
     SingleStepSyntheticReward as SingleStepSyntheticRewardType,
 )
+from .synthetic_reward.transformer_synthetic_reward import (
+    TransformerSyntheticReward as TransformerSyntheticRewardType,
+)
 from .value.fully_connected import FullyConnected as FullyConnectedValueType
 from .value.seq2reward_rnn import Seq2RewardNetBuilder as Seq2RewardNetBuilderType
 
@@ -89,3 +92,4 @@ class SyntheticRewardNetBuilder__Union(TaggedUnion):
     NGramSyntheticReward: Optional[NGramSyntheticRewardType] = None
     NGramConvNetSyntheticReward: Optional[NGramConvNetSyntheticRewardType] = None
     SequenceSyntheticReward: Optional[SequenceSyntheticRewardType] = None
+    TransformerSyntheticReward: Optional[TransformerSyntheticRewardType] = None


### PR DESCRIPTION
Summary:
Use transformers to learn the return decomposition model.
1) customized attention layers that feed positional encoding to Key & Query but not V.
2) residual connections that learn meaningful embeddings.

Differential Revision: D29346526

