### PR TITLE
Read partitioned data by Koski when distributed training is turned on

### DIFF
--- a/reagent/core/dataclasses.py
+++ b/reagent/core/dataclasses.py
@@ -68,10 +68,6 @@ else:
             if USE_VANILLA_DATACLASS:
                 try:
                     post_init_post_parse = cls.__dict__["__post_init_post_parse__"]
-                    logger.info(
-                        f"Setting {cls.__name__}.__post_init__ to its "
-                        "__post_init_post_parse__"
-                    )
                     cls.__post_init__ = post_init_post_parse
                 except KeyError:
                     pass

--- a/reagent/preprocessing/sparse_preprocessor.py
+++ b/reagent/preprocessing/sparse_preprocessor.py
@@ -31,7 +31,7 @@ def map_id_score_list(
 
 
 def make_sparse_preprocessor(
-    feature_config: rlt.ModelFeatureConfig, device: torch.device
+    feature_config: rlt.ModelFeatureConfig, device: torch.device, jit_scripted=True
 ):
     """Helper to initialize, for scripting SparsePreprocessor"""
     id2name: Dict[int, str] = feature_config.id2name
@@ -41,7 +41,11 @@ def make_sparse_preprocessor(
         ].id2index
         for fid in feature_config.id2config
     }
-    return torch.jit.script(SparsePreprocessor(id2name, id2mapping, device))
+    sparse_preprocessor = SparsePreprocessor(id2name, id2mapping, device)
+    if jit_scripted:
+        return torch.jit.script(sparse_preprocessor)
+    else:
+        return sparse_preprocessor
 
 
 class SparsePreprocessor(torch.nn.Module):

--- a/reagent/preprocessing/transforms.py
+++ b/reagent/preprocessing/transforms.py
@@ -134,7 +134,7 @@ class MapIDListFeatures:
         assert set(id_list_keys).intersection(set(id_score_list_keys)) == set()
         self.feature_config = feature_config
         self.sparse_preprocessor = make_sparse_preprocessor(
-            feature_config=feature_config, device=device
+            feature_config=feature_config, device=device, jit_scripted=False
         )
 
     def __call__(self, data):


### PR DESCRIPTION
Summary: When we set `reader_options.min_nodes` > 1, we turn on distributed training. The koski reader in each trainer process should only read `1/min_nodes` data.

Reviewed By: j-jiafei

Differential Revision: D28779856

