### PR TITLE
Fix DiscreteDqnInput.from_dict

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -757,7 +757,7 @@ class DiscreteDqnInput(BaseInput):
             next_action=batch[InputColumn.NEXT_ACTION],
             possible_actions_mask=batch[InputColumn.POSSIBLE_ACTIONS_MASK],
             possible_next_actions_mask=batch[InputColumn.POSSIBLE_NEXT_ACTIONS_MASK],
-            extras=batch[InputColumn.EXTRAS],
+            extras=ExtraData.from_dict(batch),
         )
 
 


### PR DESCRIPTION
Summary: Use `ExtraData.from_dict`

Reviewed By: czxttkl

Differential Revision: D29768249

