### PR TITLE
implement Max-Q learning method

### DIFF
--- a/reagent/core/parameters.py
+++ b/reagent/core/parameters.py
@@ -29,6 +29,19 @@ class ProblemDomain(enum.Enum):
     MDN_RNN = "mdn_rnn"
 
 
+class SlateOptMethod(enum.Enum):
+    GREEDY = "greedy"
+    TOP_K = "top_k"
+    EXACT = "exact"
+
+
+@dataclass(frozen=True)
+class SlateOptParameters(BaseDataClass):
+    __hash__ = param_hash
+
+    method: SlateOptMethod = SlateOptMethod.TOP_K
+
+
 @dataclass(frozen=True)
 class RLParameters(BaseDataClass):
     __hash__ = param_hash

--- a/reagent/gym/tests/configs/recsim/slate_q_recsim_online_maxq_topk.yaml
+++ b/reagent/gym/tests/configs/recsim/slate_q_recsim_online_maxq_topk.yaml
@@ -1,0 +1,32 @@
+env:
+  RecSim:
+    slate_size: 3
+    num_candidates: 10
+model:
+  SlateQ:
+    slate_size: 3
+    num_candidates: 10
+    slate_feature_id: 1  # filler
+    slate_score_id: [42, 42]  # filler
+    trainer_param:
+      rl:
+        maxq_learning: True
+      optimizer:
+        Adam:
+          lr: 0.001
+    net_builder:
+      FullyConnected:
+        sizes:
+        - 64
+        - 64
+        activations:
+        - leaky_relu
+        - leaky_relu
+replay_memory_size: 100000
+train_every_ts: 1
+train_after_ts: 5000
+num_train_episodes: 300
+num_eval_episodes: 20
+passing_score_bar: 154.0
+use_gpu: false
+minibatch_size: 1024

--- a/reagent/model_managers/ranking/slate_q.py
+++ b/reagent/model_managers/ranking/slate_q.py
@@ -60,6 +60,7 @@ class SlateQ(SlateQBase):
         return SlateQTrainer(
             q_network=q_network,
             q_network_target=q_network_target,
+            slate_size=self.slate_size,
             # pyre-fixme[16]: `SlateQTrainerParameters` has no attribute `asdict`.
             **self.trainer_param.asdict(),
         )


### PR DESCRIPTION
Summary:
Previously the SlateQ trainer only supports SARSA on-policy training. This diff implements a off-policy training approach based on Q-learning.

Changes are:

1. Introduced a new `slate_opt_parameters` to specify which slate optimization method to use: top_k, greedy, or exact, based on the SlateQ paper. Currently only the top_k approach is implemented;
2. When choosing the next action, instead of directly using `training_batch.next_action`, we first calculate the Q-value for each next candidate, and rank them by doc value * Q-value. And choose the indices for the top-k items as the next action.

Reviewed By: kittipatv

Differential Revision: D29660887

