### PR TITLE
Use actual slate_size when not single_select

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -268,8 +268,6 @@ class DocList(TensorDataClass):
             torch.arange(action.shape[0]).unsqueeze(1), action.shape[1], dim=1
         )
         mask = self.mask[row_idx, action]
-        # Make sure the indices are in the right range
-        assert mask.to(torch.bool).all()
         float_features = self.float_features[row_idx, action]
         value = self.value[row_idx, action]
         return DocList(float_features, mask, value)

--- a/reagent/gym/tests/configs/recsim/slate_q_recsim_online_multi_selection.yaml
+++ b/reagent/gym/tests/configs/recsim/slate_q_recsim_online_multi_selection.yaml
@@ -1,0 +1,31 @@
+env:
+  RecSim:
+    slate_size: 3
+    num_candidates: 10
+model:
+  SlateQ:
+    slate_size: 3
+    num_candidates: 10
+    slate_feature_id: 1  # filler
+    slate_score_id: [42, 42]  # filler
+    trainer_param:
+      single_selection: False
+      optimizer:
+        Adam:
+          lr: 0.001
+    net_builder:
+      FullyConnected:
+        sizes:
+        - 64
+        - 64
+        activations:
+        - leaky_relu
+        - leaky_relu
+replay_memory_size: 100000
+train_every_ts: 1
+train_after_ts: 5000
+num_train_episodes: 300
+num_eval_episodes: 20
+passing_score_bar: 154.0
+use_gpu: false
+minibatch_size: 1024

--- a/reagent/gym/tests/test_gym.py
+++ b/reagent/gym/tests/test_gym.py
@@ -71,6 +71,10 @@ REPLAY_BUFFER_GYM_TESTS_2 = [
         "SlateQ RecSim with Discount Scaled by Time Diff",
         "configs/recsim/slate_q_recsim_online_with_time_scale.yaml",
     ),
+    (
+        "SlateQ RecSim multi selection",
+        "configs/recsim/slate_q_recsim_online_multi_selection.yaml",
+    ),
     ("PossibleActionsMask DQN", "configs/functionality/dqn_possible_actions_mask.yaml"),
 ]
 


### PR DESCRIPTION
Summary:
The previous approach use the fixed slate_size, which includes padded items, and it shouldn't give use the actual average over valid Q-value estimations.

This diff fix this issue by calculating the actual slate_size summing the item mask (1 if an item is valid) over each slate.

Differential Revision: D29848923

