### PR TITLE
add option for configuring slate_size in multi selection

### DIFF
--- a/reagent/gym/tests/configs/recsim/slate_q_recsim_online_multi_selection_avg_curr.yaml
+++ b/reagent/gym/tests/configs/recsim/slate_q_recsim_online_multi_selection_avg_curr.yaml
@@ -10,7 +10,7 @@ model:
     slate_score_id: [42, 42]  # filler
     trainer_param:
       single_selection: False
-      next_slate_value_norm_method: "norm_by_next_slate_size"
+      next_slate_value_norm_method: "norm_by_current_slate_size"
       optimizer:
         Adam:
           lr: 0.001

--- a/reagent/gym/tests/test_gym.py
+++ b/reagent/gym/tests/test_gym.py
@@ -75,6 +75,10 @@ REPLAY_BUFFER_GYM_TESTS_2 = [
         "SlateQ RecSim multi selection",
         "configs/recsim/slate_q_recsim_online_multi_selection.yaml",
     ),
+    (
+        "SlateQ RecSim multi selection average by current slate size",
+        "configs/recsim/slate_q_recsim_online_multi_selection_avg_curr.yaml",
+    ),
     ("PossibleActionsMask DQN", "configs/functionality/dqn_possible_actions_mask.yaml"),
 ]
 


### PR DESCRIPTION
Summary:
If we don't enable `single_selection`, we should find a way to calculate the next slate value from all Q-values of all items on the next slate.

The default way to calculate that is by summing up all the next Q-values and average by the slate_size of the next slate.

There is another way to average by the current slate_size as well.

This wasn't an issue before since the slate_size is fixed, but after we landed D29848923 (https://github.com/facebookresearch/ReAgent/commit/5351f6313cb24fbd9ff604beaae99b66ee9eed0e), the slate size can be different.

We're not sure theoretically if either averaging method is better, so we propose this diff to allow configuring that.

The new option is called `next_slate_value_calc_method` and it can take:

- `"sum_avg_curr"`: sum the next slate Q-values and average by the current slate size;
- `"sum_avg_next"`: sum the next slate Q-values and average by the **next** slate size;

cc achechetka solofsson

Differential Revision: D29986728

