### PR TITLE
Add PPOTrainer Unit Test V2

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -53,6 +53,7 @@ class TensorDataClass(BaseDataClass):
         tensor_attr = getattr(torch.Tensor, attr, None)
 
         if tensor_attr is None or not callable(tensor_attr):
+            # TODO: can we get this working well with jupyter?
             logger.error(
                 f"Attempting to call {self.__class__.__name__}.{attr} on "
                 f"{type(self)} (instance of TensorDataClass)."
@@ -735,11 +736,37 @@ class BaseInput(TensorDataClass):
 
 @dataclass
 class DiscreteDqnInput(BaseInput):
+    """
+    See input_prototype for DQN expected input shapes
+    """
+
     action: torch.Tensor
     next_action: torch.Tensor
     possible_actions_mask: torch.Tensor
     possible_next_actions_mask: torch.Tensor
     extras: ExtraData
+
+    @classmethod
+    def input_prototype(cls, action_dim=2, batch_size=10, state_dim=3):
+        return cls(
+            state=FeatureData(float_features=torch.randn(batch_size, state_dim)),
+            next_state=FeatureData(float_features=torch.randn(batch_size, state_dim)),
+            reward=torch.rand(batch_size, 1),
+            time_diff=torch.ones(batch_size, 1),
+            step=torch.ones(batch_size, 1),
+            not_terminal=torch.ones(batch_size, 1),
+            action=F.one_hot(
+                torch.randint(high=action_dim, size=(batch_size,)),
+                num_classes=action_dim,
+            ),
+            next_action=F.one_hot(
+                torch.randint(high=action_dim, size=(batch_size,)),
+                num_classes=action_dim,
+            ),
+            possible_actions_mask=torch.ones(batch_size, action_dim),
+            possible_next_actions_mask=torch.ones(batch_size, action_dim),
+            extras=ExtraData(action_probability=torch.ones(batch_size, 1)),
+        )
 
     @classmethod
     def from_dict(cls, batch):
@@ -858,6 +885,10 @@ class PolicyNetworkInput(BaseInput):
 
 @dataclass
 class PolicyGradientInput(TensorDataClass):
+    """
+    See input_prototype for expected input dimensions
+    """
+
     state: FeatureData
     action: torch.Tensor
     reward: torch.Tensor
@@ -865,14 +896,13 @@ class PolicyGradientInput(TensorDataClass):
     possible_actions_mask: Optional[torch.Tensor] = None
 
     @classmethod
-    def input_prototype(cls):
-        num_classes = 5
-        batch_size = 10
-        state_dim = 3
-        action_dim = 2
+    def input_prototype(cls, action_dim=2, batch_size=10, state_dim=3):
         return cls(
             state=FeatureData(float_features=torch.randn(batch_size, state_dim)),
-            action=F.one_hot(torch.randint(high=num_classes, size=(batch_size,))),
+            action=F.one_hot(
+                torch.randint(high=action_dim, size=(batch_size,)),
+                num_classes=action_dim,
+            ),
             reward=torch.rand(batch_size),
             log_prob=torch.log(torch.rand(batch_size)),
             possible_actions_mask=torch.ones(batch_size, action_dim),

--- a/reagent/model_managers/policy_gradient/ppo.py
+++ b/reagent/model_managers/policy_gradient/ppo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Dict, Optional, Tuple, List
+from typing import Dict, Optional
 
 import torch
 from reagent.core import types as rlt
@@ -9,8 +9,6 @@ from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import NormalizationData
 from reagent.core.parameters import NormalizationKey
 from reagent.core.parameters import param_hash
-from reagent.data.data_fetcher import DataFetcher
-from reagent.data.reagent_data_module import ReAgentDataModule
 from reagent.gym.policies.policy import Policy
 from reagent.gym.policies.predictor_policies import create_predictor_policy_from_model
 from reagent.gym.policies.samplers.discrete_sampler import SoftmaxActionSampler
@@ -24,12 +22,8 @@ from reagent.net_builder.unions import (
 from reagent.training import PPOTrainer, PPOTrainerParameters
 from reagent.training import ReAgentLightningModule
 from reagent.workflow.types import (
-    Dataset,
     ModelFeatureConfigProvider__Union,
-    ReaderOptions,
-    ResourceOptions,
     RewardOptions,
-    RLTrainingOutput,
 )
 
 

--- a/reagent/net_builder/value/fully_connected.py
+++ b/reagent/net_builder/value/fully_connected.py
@@ -5,7 +5,7 @@ from typing import List
 import torch
 from reagent.core.dataclasses import dataclass, field
 from reagent.core.parameters import NormalizationData, param_hash
-from reagent.models.fully_connected_network import FullyConnectedNetwork
+from reagent.models.fully_connected_network import FloatFeatureFullyConnected
 from reagent.net_builder.value_net_builder import ValueNetBuilder
 from reagent.preprocessing.normalization import get_num_output_features
 
@@ -31,8 +31,10 @@ class FullyConnected(ValueNetBuilder):
         state_dim = get_num_output_features(
             state_normalization_data.dense_normalization_parameters
         )
-        return FullyConnectedNetwork(
-            [state_dim] + self.sizes + [output_dim],
-            self.activations + ["linear"],
+        return FloatFeatureFullyConnected(
+            state_dim=state_dim,
+            output_dim=output_dim,
+            sizes=self.sizes,
+            activations=self.activations,
             use_layer_norm=self.use_layer_norm,
         )

--- a/reagent/test/net_builder/test_value_net_builder.py
+++ b/reagent/test/net_builder/test_value_net_builder.py
@@ -5,6 +5,7 @@ import unittest
 
 import torch
 from reagent.core.parameters import NormalizationData, NormalizationParameters
+from reagent.core.types import FeatureData
 from reagent.net_builder import value
 from reagent.net_builder.unions import ValueNetBuilder__Union
 from reagent.preprocessing.identify_types import CONTINUOUS
@@ -25,6 +26,6 @@ class TestValueNetBuilder(unittest.TestCase):
         )
         value_network = builder.build_value_network(normalization_data)
         batch_size = 5
-        x = torch.randn(batch_size, state_dim)
+        x = FeatureData(float_features=torch.randn(batch_size, state_dim))
         y = value_network(x)
         self.assertEqual(y.shape, (batch_size, 1))

--- a/reagent/test/training/test_ppo.py
+++ b/reagent/test/training/test_ppo.py
@@ -1,0 +1,203 @@
+import unittest
+from collections import defaultdict
+from unittest import mock
+
+import torch
+from reagent.core.types import PolicyGradientInput
+from reagent.evaluation.evaluator import get_metrics_to_score
+from reagent.gym.policies.policy import Policy
+from reagent.gym.policies.samplers.discrete_sampler import SoftmaxActionSampler
+from reagent.models.dueling_q_network import DuelingQNetwork
+from reagent.models.fully_connected_network import FloatFeatureFullyConnected
+from reagent.training.parameters import PPOTrainerParameters
+from reagent.training.ppo_trainer import PPOTrainer
+from reagent.workflow.types import RewardOptions
+
+
+class TestPPO(unittest.TestCase):
+    def setUp(self):
+        # preparing various components for qr-dqn trainer initialization
+        self.batch_size = 3
+        self.state_dim = 10
+        self.action_dim = 2
+        self.num_layers = 2
+        self.sizes = [20 for _ in range(self.num_layers)]
+        self.activations = ["relu" for _ in range(self.num_layers)]
+        self.use_layer_norm = False
+        self.softmax_temperature = 1
+
+        self.actions = [str(i) for i in range(self.action_dim)]
+        self.params = PPOTrainerParameters(actions=self.actions, normalize=False)
+        self.reward_options = RewardOptions()
+        self.metrics_to_score = get_metrics_to_score(
+            self.reward_options.metric_reward_values
+        )
+
+        self.policy_network = DuelingQNetwork.make_fully_connected(
+            state_dim=self.state_dim,
+            action_dim=self.action_dim,
+            layers=self.sizes,
+            activations=self.activations,
+        )
+        self.sampler = SoftmaxActionSampler(temperature=self.softmax_temperature)
+        self.policy = Policy(scorer=self.policy_network, sampler=self.sampler)
+
+        self.value_network = FloatFeatureFullyConnected(
+            state_dim=self.state_dim,
+            output_dim=1,
+            sizes=self.sizes,
+            activations=self.activations,
+            use_layer_norm=self.use_layer_norm,
+        )
+
+    def _construct_trainer(self, new_params=None, use_value_net=True):
+        value_network = self.value_network if use_value_net else None
+        params = new_params if new_params else self.params
+
+        trainer = PPOTrainer(
+            policy=self.policy, value_net=value_network, **params.asdict()
+        )
+        trainer.optimizers = mock.Mock(return_value=[0, 0])
+        return trainer
+
+    def test_init(self):
+        trainer = self._construct_trainer()
+
+        self.assertEqual(
+            type(trainer.value_loss_fn), type(torch.nn.MSELoss(reduction="mean"))
+        )
+
+        with self.assertRaises(AssertionError):
+            new_params = PPOTrainerParameters(ppo_epsilon=-1)
+            self._construct_trainer(new_params)
+
+        with self.assertRaises(AssertionError):
+            new_params = PPOTrainerParameters(ppo_epsilon=2)
+            self._construct_trainer(new_params)
+
+        with self.assertRaises(AssertionError):
+            params = PPOTrainerParameters(actions=["1", "2"], normalize=True)
+            trainer = self._construct_trainer(new_params=params)
+
+    def test__trajectory_to_losses(self):
+        inp = PolicyGradientInput.input_prototype(
+            batch_size=self.batch_size,
+            action_dim=self.action_dim,
+            state_dim=self.state_dim,
+        )
+        # Normalize + offset clamp min
+        params = PPOTrainerParameters(
+            actions=["1", "2"], normalize=True, offset_clamp_min=True
+        )
+        trainer = self._construct_trainer(new_params=params, use_value_net=False)
+        losses = trainer._trajectory_to_losses(inp)
+        self.assertEqual(len(losses), 1)
+        self.assertTrue("ppo_loss" in losses)
+
+        trainer = self._construct_trainer()
+        losses = trainer._trajectory_to_losses(inp)
+        self.assertEqual(len(losses), 2)
+        self.assertTrue("ppo_loss" in losses and "value_net_loss" in losses)
+        # entropy weight should always lower ppo_loss
+        trainer.entropy_weight = 1.0
+        entropy_losses = trainer._trajectory_to_losses(inp)
+        self.assertTrue(entropy_losses["ppo_loss"] < losses["ppo_loss"])
+
+    def test_configure_optimizers(self):
+        # Ordering is value then policy
+        trainer = self._construct_trainer()
+        optimizers = trainer.configure_optimizers()
+        self.assertTrue(
+            torch.all(
+                torch.isclose(
+                    optimizers[0]["optimizer"].param_groups[0]["params"][0],
+                    list(trainer.value_net.fc.dnn[0].parameters())[0],
+                )
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                torch.isclose(
+                    optimizers[1]["optimizer"].param_groups[0]["params"][0],
+                    list(trainer.scorer.shared_network.fc.dnn[0].parameters())[0],
+                )
+            )
+        )
+
+    def test_get_optimizers(self):
+        # ordering covered in test_configure_optimizers
+        trainer = self._construct_trainer()
+        optimizers = trainer.get_optimizers()
+        self.assertIsNotNone(optimizers[0])
+        trainer = self._construct_trainer(use_value_net=False)
+        optimizers = trainer.get_optimizers()
+        self.assertIsNone(optimizers[0])
+
+    def test_training_step(self):
+        trainer = self._construct_trainer()
+        inp = defaultdict(lambda: torch.ones(1, 5))
+        trainer.update_model = mock.Mock()
+        trainer.training_step(inp, batch_idx=1)
+        trainer.update_model.assert_called_with()
+        trainer.update_freq = 10
+        trainer.update_model = mock.Mock()
+        trainer.training_step(inp, batch_idx=1)
+        trainer.update_model.assert_not_called()
+
+    def test_update_model(self):
+        trainer = self._construct_trainer()
+        # can't update empty model
+        with self.assertRaises(AssertionError):
+            trainer.update_model()
+        # _update_model called with permutation of traj_buffer contents update_epoch # times
+        trainer = self._construct_trainer(
+            new_params=PPOTrainerParameters(
+                ppo_batch_size=1,
+                update_epochs=2,
+                update_freq=2,
+                normalize=False,
+            )
+        )
+        trainer.traj_buffer = [1, 2]
+        trainer._update_model = mock.Mock()
+        trainer.update_model()
+        calls = [mock.call([1]), mock.call([2]), mock.call([1]), mock.call([2])]
+        trainer._update_model.assert_has_calls(calls, any_order=True)
+        # trainer empties buffer
+        self.assertEqual(trainer.traj_buffer, [])
+
+        # _update_model
+        trainer = self._construct_trainer()
+        value_net_opt_mock = mock.Mock()
+        ppo_opt_mock = mock.Mock()
+        trainer.get_optimizers = mock.Mock(
+            return_value=[value_net_opt_mock, ppo_opt_mock]
+        )
+        trainer._trajectory_to_losses = mock.Mock(
+            side_effect=[
+                {"ppo_loss": torch.tensor(1), "value_net_loss": torch.tensor(2)},
+                {"ppo_loss": torch.tensor(3), "value_net_loss": torch.tensor(4)},
+            ]
+        )
+        trainer.manual_backward = mock.Mock()
+        inp1 = PolicyGradientInput.input_prototype(
+            batch_size=1, action_dim=1, state_dim=1
+        )
+        inp2 = PolicyGradientInput.input_prototype(
+            batch_size=1, action_dim=1, state_dim=1
+        )
+
+        trainer._update_model([inp1, inp2])
+
+        trainer._trajectory_to_losses.assert_has_calls(
+            [mock.call(inp1), mock.call(inp2)]
+        )
+        value_net_opt_mock.zero_grad.assert_called()
+        value_net_opt_mock.step.assert_called()
+
+        ppo_opt_mock.zero_grad.assert_called()
+        ppo_opt_mock.step.assert_called()
+
+        trainer.manual_backward.assert_has_calls(
+            [mock.call(torch.tensor(6)), mock.call(torch.tensor(4))]
+        )

--- a/reagent/training/ppo_trainer.py
+++ b/reagent/training/ppo_trainer.py
@@ -3,7 +3,7 @@
 import inspect
 import logging
 from dataclasses import field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import reagent.core.types as rlt
 import torch
@@ -32,7 +32,7 @@ class PPOTrainer(ReAgentLightningModule):
     def __init__(
         self,
         policy: Policy,
-        gamma: float = 0.0,
+        gamma: float = 0.9,
         optimizer: Optimizer__Union = field(  # noqa: B008
             default_factory=Optimizer__Union.default
         ),
@@ -72,12 +72,14 @@ class PPOTrainer(ReAgentLightningModule):
         self.value_net = value_net
         if value_net is not None:
             self.value_loss_fn = torch.nn.MSELoss(reduction="mean")
+            assert (
+                not self.normalize
+            ), "Can't apply a value baseline and normalize rewards simultaneously"
         assert (ppo_epsilon >= 0) and (
             ppo_epsilon <= 1
         ), "ppo_epslion has to be in [0;1]"
 
         self.traj_buffer = []
-        self.step = 0
 
     def _trajectory_to_losses(
         self, trajectory: rlt.PolicyGradientInput
@@ -91,6 +93,7 @@ class PPOTrainer(ReAgentLightningModule):
         rewards = trajectory.reward.detach()
         scorer_inputs = []
         if inspect.getattr_static(trajectory, "graph", None) is not None:
+            # TODO: can this line be hit currently in ReAgent?
             # GNN
             scorer_inputs.append(trajectory.graph)
         else:
@@ -108,10 +111,6 @@ class PPOTrainer(ReAgentLightningModule):
         if self.offset_clamp_min:
             offset_reinforcement = offset_reinforcement.clamp(min=0)
         if self.value_net is not None:
-            if self.normalize:
-                raise RuntimeError(
-                    "Can't apply a baseline and normalize rewards simultaneously"
-                )
             # subtract learned value function baselines from rewards
             baselines = self.value_net(trajectory.state).squeeze()  # pyre-ignore
             # use reward-to-go as label for training the value function
@@ -165,17 +164,22 @@ class PPOTrainer(ReAgentLightningModule):
 
     # pyre-fixme[14]: `training_step` overrides method defined in
     #  `ReAgentLightningModule` inconsistently.
-    def training_step(self, training_batch: rlt.PolicyGradientInput, batch_idx: int):
+    def training_step(
+        self,
+        training_batch: Union[rlt.PolicyGradientInput, Dict[str, torch.Tensor]],
+        batch_idx: int,
+    ):
         if isinstance(training_batch, dict):
             training_batch = rlt.PolicyGradientInput.from_dict(training_batch)
 
         self.traj_buffer.append(training_batch)
-        self.step += 1
-        if self.step % self.update_freq == 0:
+        if len(self.traj_buffer) == self.update_freq:
             self.update_model()
 
     def update_model(self):
-        assert len(self.traj_buffer) == self.update_freq
+        assert (
+            len(self.traj_buffer) == self.update_freq
+        ), "trajectory buffer does not have sufficient samples for model_update"
         for _ in range(self.update_epochs):
             # iterate through minibatches of PPO updates in random order
             random_order = torch.randperm(len(self.traj_buffer))

--- a/reagent/training/sac_trainer.py
+++ b/reagent/training/sac_trainer.py
@@ -212,9 +212,7 @@ class SACTrainer(RLTrainerMixin, ReAgentLightningModule):
         #
 
         if self.value_network is not None:
-            next_state_value = self.value_network_target(
-                training_batch.next_state.float_features
-            )
+            next_state_value = self.value_network_target(training_batch.next_state)
         else:
             next_state_actor_output = self.actor_network(training_batch.next_state)
             next_state_actor_action = (
@@ -268,7 +266,7 @@ class SACTrainer(RLTrainerMixin, ReAgentLightningModule):
             actor_log_prob = actor_log_prob.detach()
 
         if self.crr_config is not None:
-            cur_value = self.value_network(training_batch.state.float_features)
+            cur_value = self.value_network(training_batch.state)
             advantage = (min_q_actor_value - cur_value).detach()
             # pyre-fixme[16]: `Optional` has no attribute `get_weight_from_advantage`.
             crr_weight = self.crr_config.get_weight_from_advantage(advantage)
@@ -323,7 +321,7 @@ class SACTrainer(RLTrainerMixin, ReAgentLightningModule):
         #
 
         if self.value_network is not None:
-            state_value = self.value_network(state.float_features)
+            state_value = self.value_network(state)
 
             if self.logged_action_uniform_prior:
                 log_prob_a = torch.zeros_like(min_q_actor_value)


### PR DESCRIPTION
Summary:
Adds dedicated unit test for PPO Trainer, additionally:
- Fixes a bug with fully connected value net
- Fixes some bugs in PPO training around using value net
- Adds possible_action_mask to DuelingQNetwork

Note: a continuation of D30114686 (https://github.com/facebookresearch/ReAgent/commit/8d00eb1d1c59fa76c064f9f0524a51ed240af805), which I reverted after it caused some CircleCI failures

Differential Revision: D30342897

