### PR TITLE
Disable parallel policy evaluation by default

### DIFF
--- a/reagent/gym/runners/gymrunner.py
+++ b/reagent/gym/runners/gymrunner.py
@@ -67,7 +67,7 @@ def evaluate_for_n_episodes(
     agent: Agent,
     max_steps: Optional[int] = None,
     gammas: Sequence[float] = (1.0,),
-    num_processes: int = 4,
+    num_processes: int = 0,
 ) -> np.ndarray:
     """Return an np array A of shape n x len(gammas)
     where A[i, j] = ith episode evaluated with gamma=gammas[j].


### PR DESCRIPTION
Summary: Catching PickleError stops working as it's now RuntimeError. Since RuntimeError is quite generic, I don't think it's a good idea to catch it. Therefore, let's just disable parallel evaluation.

Reviewed By: igfox

Differential Revision: D30730645

