### PR TITLE
Fix data loader identity

### DIFF
--- a/reagent/model_managers/actor_critic_base.py
+++ b/reagent/model_managers/actor_critic_base.py
@@ -243,5 +243,4 @@ class ActorCriticDataModule(ManualDataModule):
         return PolicyNetworkBatchPreprocessor(
             state_preprocessor=state_preprocessor,
             action_preprocessor=action_preprocessor,
-            use_gpu=self.resource_options.use_gpu,
         )

--- a/reagent/model_managers/discrete_dqn_base.py
+++ b/reagent/model_managers/discrete_dqn_base.py
@@ -188,10 +188,8 @@ class DiscreteDqnDataModule(ManualDataModule):
     def build_batch_preprocessor(self) -> BatchPreprocessor:
         state_preprocessor = Preprocessor(
             self.state_normalization_data.dense_normalization_parameters,
-            use_gpu=self.resource_options.use_gpu,
         )
         return DiscreteDqnBatchPreprocessor(
             num_actions=len(self.model_manager.action_names),
             state_preprocessor=state_preprocessor,
-            use_gpu=self.resource_options.use_gpu,
         )

--- a/reagent/model_managers/model_manager.py
+++ b/reagent/model_managers/model_manager.py
@@ -136,13 +136,14 @@ class ModelManager:
             checkpoint_path=checkpoint_path,
             resource_options=resource_options,
         )
+
         rank = get_rank()
         if rank == 0:
-            logger = lightning_trainer.logger
+            trainer_logger = lightning_trainer.logger
             # pyre-ignore
-            logger_data = logger.line_plot_aggregated
+            logger_data = trainer_logger.line_plot_aggregated
             # pyre-ignore
-            logger.clear_local_data()
+            trainer_logger.clear_local_data()
             if reporter is None:
                 training_report = None
             else:

--- a/reagent/preprocessing/batch_preprocessor.py
+++ b/reagent/preprocessing/batch_preprocessor.py
@@ -23,7 +23,7 @@ def batch_to_device(batch: Dict[str, torch.Tensor], device: torch.device):
 
 class DiscreteDqnBatchPreprocessor(BatchPreprocessor):
     def __init__(
-        self, num_actions: int, state_preprocessor: Preprocessor, use_gpu: bool
+        self, num_actions: int, state_preprocessor: Preprocessor, use_gpu: bool = False
     ):
         super().__init__()
         self.num_actions = num_actions
@@ -117,7 +117,7 @@ class PolicyNetworkBatchPreprocessor(BatchPreprocessor):
         self,
         state_preprocessor: Preprocessor,
         action_preprocessor: Preprocessor,
-        use_gpu: bool,
+        use_gpu: bool = False,
     ):
         super().__init__()
         self.state_preprocessor = state_preprocessor


### PR DESCRIPTION
Summary:
We need to have a unique identity for each epoch and dataset type (train/val/test).
We must use cpu-based batch preprocessor
Some other small fixes.

Differential Revision: D30861672

