### PR TITLE
Change clampping of probability feature preprocessing.

### DIFF
--- a/reagent/preprocessing/preprocessor.py
+++ b/reagent/preprocessing/preprocessor.py
@@ -238,7 +238,7 @@ class Preprocessor(Module):
         input: torch.Tensor,
         norm_params: List[NormalizationParameters],
     ) -> torch.Tensor:
-        clamped_input = torch.clamp(input, 0.01, 0.99)
+        clamped_input = torch.clamp(input, 1e-5, 1 - 1e-5)
         return self.negative_one_tensor * (
             ((self.one_tensor / clamped_input) - self.one_tensor).log()
         )


### PR DESCRIPTION
Summary:
Use [0.01, 0.99] may cause some performance loss in boosting with entropy
metrics.

Differential Revision: D31346456

