### PR TITLE
Remove deprecated dataloader arguments in Trainer methods (#10325)

### DIFF
--- a/reagent/test/training/test_multi_stage_trainer.py
+++ b/reagent/test/training/test_multi_stage_trainer.py
@@ -163,7 +163,7 @@ class TestMultiStageTrainer(unittest.TestCase):
             make_dataset(input_dim, test_size),
             batch_size=5,
         )
-        trainer.test(test_dataloaders=test_dataloader)
+        trainer.test(dataloaders=test_dataloader)
         print(f"stage1 {stage1._call_count}")
         print(f"stage2 {stage2._call_count}")
         self.assertEqual(stage1._call_count["train"], 60)


### PR DESCRIPTION
Summary:
### New commit log messages
  412f0a4d2 Remove deprecated dataloader arguments in Trainer methods (#10325)

Reviewed By: tangbinh

Differential Revision: D32261342

