### PR TITLE
reagent MAB: randomize argmax, add lower bound on variance estimate, add TunedUCB

### DIFF
--- a/reagent/mab/thompson_sampling.py
+++ b/reagent/mab/thompson_sampling.py
@@ -11,7 +11,7 @@ class BaseThompsonSampling(MABAlgo):
     def _get_posterior_samples(self) -> Tensor:
         pass
 
-    def forward(self):
+    def get_scores(self):
         return self._get_posterior_samples()
 
 
@@ -35,17 +35,24 @@ class NormalGammaThompson(BaseThompsonSampling):
     """
     The Thompson Sampling MAB with Normal-Gamma distribution for rewards.
     Appropriate for MAB with normally distributed rewards.
-    We use poterior update equations from
+    We use posterior update equations from
         https://en.wikipedia.org/wiki/Normal-gamma_distribution#Posterior_distribution_of_the_parameters
     """
 
     def __init__(
         self,
+        randomize_ties: bool = True,
+        min_num_obs_per_arm: int = 1,
         *,
         n_arms: Optional[int] = None,
         arm_ids: Optional[List[str]] = None,
     ):
-        super().__init__(n_arms=n_arms, arm_ids=arm_ids)
+        super().__init__(
+            randomize_ties=randomize_ties,
+            n_arms=n_arms,
+            arm_ids=arm_ids,
+            min_num_obs_per_arm=min_num_obs_per_arm,
+        )
         self.mus = torch.zeros(self.n_arms)
         self.alpha_0 = 1.5  # initial value of the alpha parameter
         self.lambda_0 = 1.0  # initial value of the lambda parameter

--- a/reagent/mab/ucb.py
+++ b/reagent/mab/ucb.py
@@ -14,37 +14,42 @@ class BaseUCB(MABAlgo, ABC):
     Args:
         estimate_variance: If True, per-arm reward variance is estimated and we multiply thconfidence interval width
             by its square root
+        min_variance: The lower bound applied to the estimated variance. If variance is not estimated, this value is used instead of an estimate.
         alpha: Scalar multiplier for confidence interval width. Values above 1.0 make exploration more aggressive, below 1.0 less aggressive
     """
 
     def __init__(
         self,
+        randomize_ties: bool = True,
         estimate_variance: bool = True,
+        min_variance: float = 0.0,
         alpha: float = 1.0,
+        min_num_obs_per_arm: int = 1,
         *,
         n_arms: Optional[int] = None,
         arm_ids: Optional[List[str]] = None,
     ):
-        super().__init__(n_arms=n_arms, arm_ids=arm_ids)
+        super().__init__(
+            n_arms=n_arms,
+            arm_ids=arm_ids,
+            randomize_ties=randomize_ties,
+            min_num_obs_per_arm=min_num_obs_per_arm,
+        )
         self.estimate_variance = estimate_variance
+        self.min_variance = torch.tensor(min_variance)
         self.alpha = alpha
-
-    @abstractmethod
-    def get_ucb_scores(self) -> Tensor:
-        pass
-
-    def forward(self) -> Tensor:
-        return self.get_ucb_scores()
 
     @property
     def var(self):
         # return empirical variance of rewards for each arm
         if self.estimate_variance:
-            return self.total_sum_reward_squared_per_arm / self.total_n_obs_per_arm - (
-                (self.total_sum_reward_per_arm / self.total_n_obs_per_arm) ** 2
+            return torch.fmax(
+                self.min_variance,
+                self.total_sum_reward_squared_per_arm / self.total_n_obs_per_arm
+                - ((self.total_sum_reward_per_arm / self.total_n_obs_per_arm) ** 2),
             )
         else:
-            return 1.0
+            return self.min_variance
 
 
 class UCB1(BaseUCB):
@@ -53,7 +58,7 @@ class UCB1(BaseUCB):
     Reference: https://www.cs.bham.ac.uk/internal/courses/robotics/lectures/ucb1.pdf
     """
 
-    def get_ucb_scores(self) -> Tensor:
+    def get_scores(self) -> Tensor:
         """
         Get per-arm UCB scores. The formula is
         UCB_i = AVG([rewards_i]) + SQRT(2*LN(T)/N_i*VAR)
@@ -66,12 +71,7 @@ class UCB1(BaseUCB):
         log_t_over_ni = (
             math.log(self.total_n_obs_all_arms + 1) / self.total_n_obs_per_arm
         )
-        ucb = avg_rewards + self.alpha * torch.sqrt(2 * log_t_over_ni * self.var)
-        return torch.where(
-            self.total_n_obs_per_arm > 0,
-            ucb,
-            torch.tensor(torch.inf, dtype=torch.float),
-        )
+        return avg_rewards + self.alpha * torch.sqrt(2 * log_t_over_ni * self.var)
 
 
 class MetricUCB(BaseUCB):
@@ -81,7 +81,7 @@ class MetricUCB(BaseUCB):
     Reference: https://arxiv.org/pdf/0809.4882.pdf
     """
 
-    def get_ucb_scores(self) -> Tensor:
+    def get_scores(self) -> Tensor:
         """
         Get per-arm UCB scores. The formula is
         UCB_i = AVG([rewards_i]) + SQRT(AVG([rewards_i]) * LN(T+1)/N_i) + LN(T+1)/N_i
@@ -93,20 +93,53 @@ class MetricUCB(BaseUCB):
         log_t_over_ni = (
             math.log(self.total_n_obs_all_arms + 1) / self.total_n_obs_per_arm
         )
-        ucb = avg_rewards + self.alpha * (
+        return avg_rewards + self.alpha * (
             torch.sqrt(avg_rewards * log_t_over_ni) + log_t_over_ni
         )
-        return torch.where(
-            self.total_n_obs_per_arm > 0,
-            ucb,
-            torch.tensor(torch.inf, dtype=torch.float),
+
+
+class UCBTuned(BaseUCB):
+    """
+    Implementation of the UCB-Tuned algorithm from Section 4 of  https://link.springer.com/content/pdf/10.1023/A:1013689704352.pdf
+    Biggest difference from basic UCB is that per-arm reward variance is estimated.
+    IMPORTANT: This algorithm should only be used if the rewards of each arm have Bernoulli distribution.
+    """
+
+    def get_scores(self) -> Tensor:
+        """
+        Get per-arm UCB scores. The formula is
+        UCB_i = AVG([rewards_i]) + SQRT(LN(T)/N_i * min(V_i, 0.25))
+        where V_i is a conservative variance estimate of arm i:
+            V_i = AVG([rewards_i**2]) - AVG([rewards_i])**2 + sqrt(2ln(t) / n_i)
+
+        Returns:
+            Tensor: An array of UCB scores (one per arm)
+        """
+        avg_rewards = self.get_avg_reward_values()
+        log_t_over_ni = (
+            math.log(self.total_n_obs_all_arms + 1) / self.total_n_obs_per_arm
+        )
+        per_arm_var_est = (
+            self.total_sum_reward_squared_per_arm / self.total_n_obs_per_arm
+            - avg_rewards ** 2
+            + torch.sqrt(
+                2 * log_t_over_ni
+            )  # additional term to make the estimate conservative (unlikely to underestimate)
+        )
+        return avg_rewards + torch.sqrt(
+            log_t_over_ni * torch.fmin(per_arm_var_est, torch.tensor(0.25))
         )
 
 
-def get_bernoulli_tuned_ucb_scores(n_obs_per_arm, num_success_per_arm):
-    # a minimalistic function that implements Tuned UCB for Bernoulli bandit
-    avg_rewards = n_obs_per_arm / num_success_per_arm
-    log_t_over_ni = torch.log(torch.sum(n_obs_per_arm)) / num_success_per_arm
+def get_bernoulli_ucb_tuned_scores(
+    n_obs_per_arm: Tensor, num_success_per_arm: Tensor
+) -> Tensor:
+    """
+    a minimalistic function that implements UCB-Tuned for Bernoulli bandit
+    it's here only to benchmark execution time penalty incurred by the class-based implementation
+    """
+    avg_rewards = num_success_per_arm / n_obs_per_arm
+    log_t_over_ni = torch.log(torch.sum(n_obs_per_arm)) / n_obs_per_arm
     per_arm_var_est = (
         avg_rewards
         - avg_rewards ** 2
@@ -114,4 +147,4 @@ def get_bernoulli_tuned_ucb_scores(n_obs_per_arm, num_success_per_arm):
             2 * log_t_over_ni
         )  # additional term to make the estimate conservative (unlikely to underestimate)
     )
-    return avg_rewards + torch.sqrt(log_t_over_ni * per_arm_var_est)
+    return avg_rewards + torch.sqrt(log_t_over_ni * torch.fmin(per_arm_var_est, 0.25))


### PR DESCRIPTION
Summary:
1. Make argmax return random index from argmax set instead of returning the 1st index from the argmax set.
2. Add UCB Tuned
3. Add lower bound on estimated reward variance

Differential Revision: D32410581

