### PR TITLE
update Java version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
             curl -s "https://get.sdkman.io" | bash
             source "$HOME/.sdkman/bin/sdkman-init.sh"
             sdk version
-            sdk install java 8.0.272.hs-adpt
+            sdk install java 8.0.292.hs-adpt
             sdk install scala
             sdk install maven
             sdk install spark 3.1.1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,7 +49,7 @@ To build from source, you'll need JDK, Scala, & Maven. We will use `SDKMAN! <htt
    curl -s "https://get.sdkman.io" | bash
    source "$HOME/.sdkman/bin/sdkman-init.sh"
    sdk version
-   sdk install java 8.0.272.hs-adpt
+   sdk install java 8.0.292.hs-adpt
    sdk install scala
    sdk install maven
 


### PR DESCRIPTION
Summary:
The Java version that we were using in OSS (8.0.272.hs-adpt) seems to have been removed from sdkman
See https://app.circleci.com/pipelines/github/facebookresearch/ReAgent/2142/workflows/fc99db2e-7b69-4331-abb8-ea798aa13ec4/jobs/18221
The closest available version is 8.0.292.hs-adpt

Differential Revision: D32509203

