### PR TITLE
Update CircleCI config to use a newer Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
 
   rasp_test_mac:
     macos:
-      xcode: 11.3.0
+      xcode: 13.2.1
     steps:
       - checkout_merge
       - rasp_build_deps:


### PR DESCRIPTION
Summary:
The current version 11.3.0 is going to be deprecated soon. Switch our jobs to the highest version of Xcode as recommended.

The full list of Xcode versions that are available: https://urldefense.com/v3/__https://go.circleci.com/NDg1LVpNSC02MjYAAAGBeOzdGHbPV3GF6dow_mnielqRftmf3jkavLpdgGfA0_Jp1uRUkK1aSMY7wVpolG11FH_ZSgg=__;!!Bt8RZUm9aw!r6QpSB3ZU-ROLgB75dnnvWIsbokMsxcPiE36ptsjuRFvogdwt9NvRHcx$

Differential Revision: D33282621

