### PR TITLE
Add sparse features to reward decomposition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,24 +138,30 @@ commands:
         default: false
     steps:
       - run:
-          # ubuntu-1604-cuda-10.2:202012-01 image has python2.7 by default
-          # we need to use python3.8 for tests
+          # ubuntu-1604-cuda-10.2:202012-01 image (the image we are using)
+          # has python2.7 by default. However, we need to use python3.8
+          # for tests. Therefore, we need to install python3.8 first.
           command: |
             pyenv install -v 3.8.1
             pyenv global 3.8.1
             sudo apt update
-            sudo apt install cmake
-            sudo apt install swig
             pip install --upgrade pip --progress-bar off
-            pip install --upgrade wheel setuptools --progress-bar off
+            pip install --upgrade cmake wheel setuptools --progress-bar off
+            sudo apt install swig
             pip install tox==3.20.1 --progress-bar off
       - when:
           condition: << parameters.install_gym >>
           steps:
+            # when/unless clauses act as if ... else ...
+            # if is_ubuntu_gpu is True, we install cuda-supported pytorch
+            # otherwise, we install cpu-supported pytorch
             - when:
                 condition: << parameters.is_ubuntu_gpu >>
                 steps:
                   - run:
+                      # pip install .[gym,test] will trigger to install packages specified in setup.cfg
+                      # "-e" option will activate the development mode (a symlink to the code in ReAgent
+                      # will be created in site-packages directory)
                       command: |
                         pip install -e .[gym,test] --pre -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html --progress-bar off
             - unless:
@@ -164,6 +170,7 @@ commands:
                   - run:
                       command: |
                         pip install -e .[gym,test] --pre -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --progress-bar off
+
 
   run_unittest:
     description: Run unittests, coverage and save results

--- a/reagent/core/torchrec_types.py
+++ b/reagent/core/torchrec_types.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+from reagent.core.fb_checker import IS_FB_ENVIRONMENT
+
+
+if IS_FB_ENVIRONMENT:
+    from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, JaggedTensor  # noqa
+else:
+    # TODO: KeyedJaggedTensor/JaggedTensor are dummy classes in OSS
+    # We haven't been able to install torchrec properly in OSS as of Jan 2022
+    class KeyedJaggedTensor:
+        def __init__(self, keys=None, lengths=None, values=None, weights=None):
+            self._weights = None
+
+        def __getitem__(self, x):
+            pass
+
+        def keys(self):
+            pass
+
+    class JaggedTensor:
+        def __init__(self):
+            self._weights = None
+
+        def values(self):
+            pass
+
+        def lengths(self):
+            pass

--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -6,7 +6,7 @@ import logging
 
 # The dataclasses in this file should be vanilla dataclass to have minimal overhead
 from dataclasses import dataclass, field
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union, Final
+from typing import Dict, List, NamedTuple, Optional, Tuple, Final
 
 # Triggering registration to registries
 import reagent.core.result_types  # noqa

--- a/reagent/workflow/types.py
+++ b/reagent/workflow/types.py
@@ -23,14 +23,6 @@ from reagent.preprocessing.normalization import (
 )
 
 
-try:
-    from reagent.fb.models.model_feature_config_builder import (  # noqa
-        ConfigeratorModelFeatureConfigProvider,
-    )
-except ImportError:
-    pass
-
-
 ModuleNameToEntityId = Dict[str, int]
 
 


### PR DESCRIPTION
Summary:
As a showcase for how to add sparse features to ReAgent

I take reference to mainly two examples:
1. `fbsource/fbcode/minimal_viable_ai/ifr_uv/train.py`
2. `fbsource/fbcode/torchrecipes/rec/dlrm_main_fb.py`

Differential Revision: D33225789

