### PR TITLE
Add missing __init__ file

### DIFF
--- a/reagent/prediction/cfeval/__init__.py
+++ b/reagent/prediction/cfeval/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.


### PR DESCRIPTION
Summary: Add missing init file in reagent/prediction/cfeval/

Reviewed By: czxttkl

Differential Revision: D33795738

