### PR TITLE
Refactor sparse arch and interaction arch (#112)

### DIFF
--- a/reagent/models/synthetic_reward_sparse_arch.py
+++ b/reagent/models/synthetic_reward_sparse_arch.py
@@ -182,10 +182,10 @@ class SingleStepSyntheticSparseArchRewardNet(nn.Module):
         for conf in embedding_bag_collection.embedding_bag_configs:
             sparse_feature_names.extend(conf.feature_names)
         self.inter_arch_sparse_and_state_dense = InteractionArch(
-            sparse_feature_names=sparse_feature_names
+            F,
         )
         self.inter_arch_sparse_and_action_dense = InteractionArch(
-            sparse_feature_names=sparse_feature_names
+            F,
         )
 
         interaction_output_dim = 2 * D + 2 * F + F * (F - 1) // 2


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/112

As discussed in D33960410, we want the responsibility of processing KeyedTensor into sparse features the responsibility of SparseArch.

A motivation for this is that we want to have an extension EsuhmDLRM, where all we would need to do is replace the sparse arch component. However, the esuhm sparse arch's output doesn't adhere to the current KeyedTensor output.

Reviewed By: bigning

Differential Revision: D34482853

