### PR TITLE
Improve the ReinforceTrainer

### DIFF
--- a/reagent/gym/tests/configs/cartpole/discrete_reinforce_cartpole_online.yaml
+++ b/reagent/gym/tests/configs/cartpole/discrete_reinforce_cartpole_online.yaml
@@ -12,6 +12,8 @@ model:
       optimizer:
         Adam:
           lr: 0.001
+      normalize: False
+      subtract_mean: True
     policy_net_builder:
       FullyConnected:
         sizes:


### PR DESCRIPTION
Summary:
Improve the reinforce trainer by
1. Allowing reward mean subtraction without normalization,
2. Providing the option to log training loss and ips ratio mean per epoch.

Reviewed By: alexnikulkov

Differential Revision: D34688279

