### PR TITLE
FbContBanditBatchPreprocessor: add context-arm features; rename state->context, action->arm

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -1096,7 +1096,7 @@ class FrechetSortConfig:
 
 @dataclass
 class CBInput(TensorDataClass):
-    context_action_features: torch.Tensor
+    context_arm_features: torch.Tensor
     action: Final[Optional[torch.Tensor]] = None
     reward: Final[Optional[torch.Tensor]] = None
     log_prob: Final[Optional[torch.Tensor]] = None
@@ -1107,19 +1107,17 @@ class CBInput(TensorDataClass):
         cls,
         context_dim: int = 2,
         batch_size: int = 10,
-        action_features_dim: int = 3,
-        num_actions: int = 4,
+        arm_features_dim: int = 3,
+        num_arms: int = 4,
     ) -> "CBInput":
         return cls(
-            context_action_features=torch.randn(
-                batch_size, num_actions, action_features_dim
-            )
+            context_arm_features=torch.randn(batch_size, num_arms, arm_features_dim)
         )
 
     @classmethod
     def from_dict(cls, d: Dict[str, torch.Tensor]) -> "CBInput":
         return cls(
-            context_action_features=d["context_action_features"],
+            context_arm_features=d["context_arm_features"],
             action=d.get("action", None),
             reward=d.get("reward", None),
             log_prob=d.get("log_prob", None),
@@ -1127,4 +1125,4 @@ class CBInput(TensorDataClass):
         )
 
     def __len__(self) -> int:
-        return self.context_action_features.shape[0]
+        return self.context_arm_features.shape[0]

--- a/reagent/preprocessing/types.py
+++ b/reagent/preprocessing/types.py
@@ -43,3 +43,6 @@ class InputColumn(object):
     SCORES = "scores"
     VALID_STEP = "valid_step"
     WEIGHT = "weight"
+    CONTEXT_FEATURES = "context_features"
+    ARM_FEATURES = "arm_features"
+    CONTEXT_ARM_FEATURES = "context_arm_features"

--- a/reagent/test/preprocessing/test_transforms.py
+++ b/reagent/test/preprocessing/test_transforms.py
@@ -468,7 +468,7 @@ class TestTransforms(unittest.TestCase):
         a_T = (torch.tensor([0, 1]), torch.tensor([1, 0]))
         b_T = (torch.tensor([1, 1]), torch.tensor([1, 0]))
         a_in = {1: (torch.tensor([0]), a_T)}
-        b_in = {1: (torch.tensor([0, 2]), b_T)}
+        b_in = {1: (torch.tensor([0]), b_T)}
         fls1 = transforms.FixedLengthSequences(keys=["a", "b"], sequence_id=1)
         fls2 = transforms.FixedLengthSequences(
             keys=["a", "b"], sequence_id=1, expected_length=2
@@ -510,13 +510,13 @@ class TestTransforms(unittest.TestCase):
         # Testing assertions in the call method
         # TODO testing assert regarding offsets length compared to value
         c_T = (torch.tensor([0, 1]), torch.tensor([1, 1]))
-        with self.assertRaisesRegex(Exception, "Unexpected offsets"):
+        with self.assertRaisesRegex(ValueError, "Expected all batches"):
             # wrong expected length
             fls = transforms.FixedLengthSequences(
                 keys=["a", "b"], sequence_id=1, expected_length=1
             )
             fls({"a": a_in, "b": b_in})
-        with self.assertRaisesRegex(Exception, "Unexpected offsets"):
+        with self.assertRaisesRegex(ValueError, "Expected all batches"):
             # wrong offsets
             c_in = {1: (torch.tensor([0, 1]), c_T)}
             fls = transforms.FixedLengthSequences(keys=["a", "b", "c"], sequence_id=1)


### PR DESCRIPTION
Summary:
1. Rename state -> context
2. Rename action -> arm
3. Add capability to read context-arm features from the input
4. Remove action probability from contextual bandit input (will add back in when we add algorithms which require it)
5. Improve offset validation in `FixedLengthSequences` transform

Differential Revision: D35372899

