### PR TITLE
Fix EpsilonGreedyActionSampler Runtime error and add a test to ensure greedy action selection is working

### DIFF
--- a/reagent/gym/policies/samplers/discrete_sampler.py
+++ b/reagent/gym/policies/samplers/discrete_sampler.py
@@ -149,14 +149,14 @@ class EpsilonGreedyActionSampler(Sampler):
         num_valid_actions = valid_actions_ind.float().sum(1, keepdim=True)
 
         rand_prob = self.epsilon / num_valid_actions
-        p = torch.full_like(scores, rand_prob)
+        p = torch.zeros_like(scores) + rand_prob
 
         greedy_prob = 1 - self.epsilon + rand_prob
         p[argmax] = greedy_prob.squeeze()
 
         p[~valid_actions_ind] = 0.0
 
-        assert torch.isclose(p.sum(1) == torch.ones(p.shape[0]))
+        assert torch.allclose(p.sum(1), torch.ones(p.shape[0]))
 
         m = torch.distributions.Categorical(probs=p)
         raw_action = m.sample()

--- a/reagent/gym/tests/test_epsilon_greedy_action_sampler.py
+++ b/reagent/gym/tests/test_epsilon_greedy_action_sampler.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+import torch
+from reagent.gym.policies.samplers.discrete_sampler import EpsilonGreedyActionSampler
+from reagent.test.base.horizon_test_base import HorizonTestBase
+
+
+class EpsilonGreedyActionSamplerTest(HorizonTestBase):
+    def test_greedy_selection(self):
+        scores = torch.tensor(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [5.0, 1.0, 2.0, 3.0, 4.0],
+            ]
+        )
+        sampler = EpsilonGreedyActionSampler(epsilon=0.0)
+
+        test_action = torch.tensor(
+            [
+                [0, 0, 0, 0, 1],
+                [1, 0, 0, 0, 0],
+            ],
+            dtype=torch.long,
+        )
+        action = sampler.sample_action(scores)
+
+        torch.testing.assert_allclose(action.action, test_action)
+
+        test_log_prob = torch.tensor(
+            [0.0, 0.0],
+            dtype=torch.float,
+        )
+
+        torch.testing.assert_allclose(action.log_prob, test_log_prob)
+
+    def test_uniform_random_selection(self):
+        scores = torch.tensor(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [5.0, 1.0, 2.0, 3.0, 4.0],
+            ]
+        )
+        sampler = EpsilonGreedyActionSampler(epsilon=1.0)
+
+        action = sampler.sample_action(scores)
+
+        test_log_prob = torch.tensor(
+            [-1.60944, -1.60944],
+            dtype=torch.float,
+        )
+
+        torch.testing.assert_allclose(action.log_prob, test_log_prob)


### PR DESCRIPTION
Summary: This diff fixes a runtime error with the EpsilonGreedyActionSampler, and adds a unit test to ensure that greedy action selection via this class computes correct log probs and returns the expected actions.

Reviewed By: czxttkl

Differential Revision: D35783785

