### PR TITLE
Bulk Eval workflow with hive writer

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -1101,6 +1101,8 @@ class CBInput(TensorDataClass):
     reward: Final[Optional[torch.Tensor]] = None
     log_prob: Final[Optional[torch.Tensor]] = None
     weight: Final[Optional[torch.Tensor]] = None
+    arms: Final[Optional[torch.Tensor]] = None
+    mdp_id: Final[Optional[torch.Tensor]] = None
 
     @classmethod
     def input_prototype(
@@ -1122,6 +1124,8 @@ class CBInput(TensorDataClass):
             reward=d.get("reward", None),
             log_prob=d.get("log_prob", None),
             weight=d.get("weight", None),
+            arms=d.get("arms", None),
+            mdp_id=d.get("mdp_id", None),
         )
 
     def __len__(self) -> int:

--- a/reagent/preprocessing/transforms.py
+++ b/reagent/preprocessing/transforms.py
@@ -428,6 +428,32 @@ class ColumnVector:
         return data
 
 
+class AppendExtraValues:
+    """
+    Input is of format list(tuple(tensor, tensor)) - list(tuple(value, presence)).
+    Output is of format list(tensor) with only the value extracted for the batch.
+
+    Note that this transform works on array data type only.
+    """
+
+    def __init__(self, keys: List[str]):
+        self.keys = keys
+
+    def __call__(self, data):
+        extra_val_list = []
+        for k in self.keys:
+            raw_list = data[k]
+            assert isinstance(
+                raw_list, list
+            ), f"Extra key - {k} must be of format list(tuple(tensor, tensor))"
+            assert len(raw_list) != 0, f"Extra key - {k} cannot be an empty list"
+            for raw_value in raw_list:
+                value, presence = raw_value
+                extra_val_list.append(value)
+        data[k] = extra_val_list
+        return data
+
+
 class MaskByPresence:
     """
     Expect data to be (value, presence) and return value * presence.

--- a/reagent/preprocessing/types.py
+++ b/reagent/preprocessing/types.py
@@ -46,3 +46,4 @@ class InputColumn(object):
     CONTEXT_FEATURES = "context_features"
     ARM_FEATURES = "arm_features"
     CONTEXT_ARM_FEATURES = "context_arm_features"
+    ARMS = "arms"

--- a/reagent/test/preprocessing/test_transforms.py
+++ b/reagent/test/preprocessing/test_transforms.py
@@ -76,6 +76,23 @@ class TestTransforms(unittest.TestCase):
         self.assertEqual(o1, {"a": (1, 0), "b": 2})
         self.assertEqual(o2, {"a_presence": 0, "b": 2})
 
+    def test_AppendExtraValues(self) -> None:
+        keys = ["a"]
+        av = transforms.AppendExtraValues(keys)
+        data = {
+            "a": [
+                (torch.tensor([1, 2]), torch.tensor([True, True])),
+                (torch.tensor([3, 4]), torch.BoolTensor([False, False])),
+            ]
+        }
+        out = av(data)
+        expected = {"a": [torch.tensor([1, 2]), torch.tensor([3, 4])]}
+        self.assertEqual(out["a"][0], expected["a"][0])
+        self.assertEqual(out["a"][1], expected["a"][1])
+        with self.assertRaisesRegex(Exception, "Extra key - a cannot be an empty list"):
+            empty_list = {"a": []}
+            out = av(empty_list)
+
     def test_MaskByPresence(self) -> None:
         keys = ["a", "b"]
         mbp = transforms.MaskByPresence(keys)


### PR DESCRIPTION
Summary: Add extra optional columns of mdp_id and arms in the ReAgent codebase. These are used in eval workflow for linucb.

Reviewed By: alexnikulkov

Differential Revision: D36493574

