### PR TITLE
Add check if the logger is set in dqn_trainer

### DIFF
--- a/reagent/training/dqn_trainer.py
+++ b/reagent/training/dqn_trainer.py
@@ -275,17 +275,19 @@ class DQNTrainer(DQNTrainerBaseLightning):
             .float()
             .mean(dim=0)
         )
-        self.logger.log_metrics(
-            {
-                "td_loss": td_loss,
-                "logged_actions": action_histogram,
-                "logged_propensities": logged_propensities,
-                "logged_rewards": rewards.mean(),
-                "model_values": model_values,
-                "model_action_idxs": model_action_idxs,
-            },
-            step=self.all_batches_processed,
-        )
+        # log metrics if a logger is set
+        if self.logger:
+            self.logger.log_metrics(
+                {
+                    "td_loss": td_loss,
+                    "logged_actions": action_histogram,
+                    "logged_propensities": logged_propensities,
+                    "logged_rewards": rewards.mean(),
+                    "model_values": model_values,
+                    "model_action_idxs": model_action_idxs,
+                },
+                step=self.all_batches_processed,
+            )
 
     def _dense_to_action_dict(self, dense: torch.Tensor):
         assert dense.size() == (


### PR DESCRIPTION
Summary:
In the base LightningModule class we define an optional `logger` property which may be
initialized to None, while in DQNtrainer._log_dqn method we try to access the `logger`
object without checking first if it was initialized. The issue surfaced when trying to run
unit tests analogous to those in `test_qrdqn`. This commit adds a check whether
the `logger` is initialized prior to attempting to use it.
Interestingly, the analogous QRDQNTrainer class implementation does not use the
`logger` property for logging, perhaps it's redundant?

Differential Revision: D37529027

