### PR TITLE
improve LinUCB on-demand coefficient calculation

### DIFF
--- a/reagent/models/deep_represent_linucb.py
+++ b/reagent/models/deep_represent_linucb.py
@@ -103,8 +103,6 @@ class DeepRepresentLinearRegressionUCB(LinearRegressionUCB):
 
         if ucb_alpha is None:
             ucb_alpha = self.ucb_alpha
-        if not (self.coefs_valid_for_A == self.A).all():
-            self._estimate_coefs()
         assert self.predict_ucb is True
         if self.predict_ucb:
             self.pred_u = torch.matmul(self.mlp_out, self.coefs)

--- a/reagent/test/training/cb/test_linucb.py
+++ b/reagent/test/training/cb/test_linucb.py
@@ -109,7 +109,7 @@ class TestLinUCB(unittest.TestCase):
             scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-5
         )
 
-        scorer._estimate_coefs()
+        scorer._calculate_coefs()
         npt.assert_equal(scorer.A.numpy(), scorer.coefs_valid_for_A.numpy())
 
         npt.assert_allclose(


### PR DESCRIPTION
Summary: Make `coefs` a property, instead of an attribute. This property automatically checks if the currently saved coefficient value is valid (computed using the current values of `A` and `b`) and uses it if so. If the current saved coefficient value is invalid, we compute the new value as `coefs = A**(-1) * b` and save it

Differential Revision: D38283370

