### PR TITLE
Reagent DeepRepresentLinucb [1/x]

### DIFF
--- a/reagent/models/deep_represent_linucb.py
+++ b/reagent/models/deep_represent_linucb.py
@@ -1,0 +1,121 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+import logging
+from typing import List, Optional
+
+import torch
+from reagent.models.fully_connected_network import FullyConnectedNetwork
+from reagent.models.linear_regression import batch_quadratic_form, LinearRegressionUCB
+from torch import nn
+
+logger = logging.getLogger(__name__)
+
+
+class DeepRepresentLinearRegressionUCB(LinearRegressionUCB):
+    """
+    It is a multiple layer regression model that output UCB score.
+    The first N layers are trainable by torch optimizer().
+    The last layer is the traditional LinUCB, and it is not updated by optimizer,
+        but still will be updated by matrix computations.
+
+    Example :
+        Features(dim=9) --> deep_represent_layers --> Features(dim=3) --> LinUCB --> ucb score
+
+        DeepRepresentLinUCBTrainer(
+        (scorer): DeepRepresentLinearRegressionUCB(
+            (deep_represent_layers): FullyConnectedNetwork(
+            (dnn): Sequential(
+                (0): Linear(in_features=9, out_features=6, bias=True)
+                (1): ReLU()
+                (2): Linear(in_features=6, out_features=3, bias=True)
+                (3): Identity()
+            )
+            )
+        )
+        (loss_fn): MSELoss()
+        )
+    """
+
+    def __init__(
+        self,
+        raw_input_dim: int,  # raw feature
+        sizes: List[int],  # MLP hidden layers of the deep_represent module
+        linucb_inp_dim: int,  # output from deep_represent module, i.e., input to LinUCB module
+        activations: List[str],
+        *,
+        predict_ucb: float = True,
+        output_activation: str = "linear",
+        use_batch_norm: bool = False,
+        dropout_ratio: float = 0.0,
+        normalized_output: bool = False,
+        use_layer_norm: bool = False,
+        ucb: Optional[torch.Tensor] = None,
+        mlp_out: torch.Tensor = None,  # pyre-fixme; Attribute has type `Tensor`; used as `None`.
+        pred_u: torch.Tensor = None,  # pyre-fixme; Attribute has type `Tensor`; used as `None`.
+        pred_sigma: torch.Tensor = None,  # pyre-fixme; Attribute has type `Tensor`; used as `None`.
+        mlp_layers: nn.Module = None,  # pyre-fixme; Attribute has type `nn.Module`; used as `None`.
+    ):
+        super().__init__(input_dim=linucb_inp_dim, predict_ucb=predict_ucb)
+
+        assert raw_input_dim > 0, "raw_input_dim must be > 0, got {}".format(
+            raw_input_dim
+        )
+        assert linucb_inp_dim > 0, "linucb_inp_dim must be > 0, got {}".format(
+            linucb_inp_dim
+        )
+        assert len(sizes) == len(
+            activations
+        ), "The numbers of sizes and activations must match; got {} vs {}".format(
+            len(sizes), len(activations)
+        )
+
+        self.raw_input_dim = raw_input_dim  # input to DeepRepresent
+        self.mlp_out = mlp_out
+        self.pred_u = pred_u
+        self.pred_sigma = pred_sigma
+        if mlp_layers is None:
+            self.deep_represent_layers = FullyConnectedNetwork(
+                [raw_input_dim] + sizes + [linucb_inp_dim],
+                activations + [output_activation],
+                use_batch_norm=use_batch_norm,
+                dropout_ratio=dropout_ratio,
+                normalize_output=normalized_output,
+                use_layer_norm=use_layer_norm,
+            )
+        else:
+            self.deep_represent_layers = mlp_layers  # use customized layers
+
+    def input_prototype(self) -> torch.Tensor:
+        return torch.randn(1, self.raw_input_dim)
+
+    def forward(
+        self, inp: torch.Tensor, ucb_alpha: Optional[float] = None
+    ) -> torch.Tensor:
+        """
+        Pass raw input to mlp.
+        This mlp is trainable to optimizer, i.e., will be updated by torch optimizer(),
+            then output of mlp is passed to a LinUCB layer.
+        """
+
+        self.mlp_out = self.deep_represent_layers(
+            inp
+        )  # preprocess by DeepRepresent module before fed to LinUCB layer
+
+        if ucb_alpha is None:
+            ucb_alpha = self.ucb_alpha
+        if not (self.coefs_valid_for_A == self.A).all():
+            self._estimate_coefs()
+        assert self.predict_ucb is True
+        if self.predict_ucb:
+            self.pred_u = torch.matmul(self.mlp_out, self.coefs)
+            self.pred_sigma = ucb_alpha * torch.sqrt(
+                batch_quadratic_form(self.mlp_out, self.inv_A)
+            )
+            pred_ucb = self.pred_u + self.pred_sigma
+            # trainer needs pred_u and mlp_out to update parameters
+        else:
+            self.pred_u = torch.matmul(self.mlp_out, self.coefs)
+            raise Exception(
+                "Neural Network LinUCB currently only surport predicting ucb"
+            )
+        return pred_ucb

--- a/reagent/test/models/test_deep_represent_linucb_model.py
+++ b/reagent/test/models/test_deep_represent_linucb_model.py
@@ -1,0 +1,28 @@
+import unittest
+
+from reagent.models.deep_represent_linucb import DeepRepresentLinearRegressionUCB
+
+
+class TestDeepRepresentLinearRegressionUCB(unittest.TestCase):
+    def test_basic(self):
+        raw_input_dim = 9
+        sizes = [6]
+        linucb_inp_dim = 3
+        activations = ["relu"]
+
+        model = DeepRepresentLinearRegressionUCB(
+            raw_input_dim=raw_input_dim,
+            sizes=sizes,
+            linucb_inp_dim=linucb_inp_dim,
+            activations=activations,
+        )
+
+        raw_input = model.input_prototype()
+        self.assertEqual((1, raw_input_dim), raw_input.shape)  # check input size
+        self.assertEqual(
+            (1, linucb_inp_dim),  # check deep_represent output size
+            model.deep_represent_layers(raw_input).shape,
+        )
+        model.eval()
+        output = model(raw_input)  # check final output size
+        self.assertEqual((1,), output.shape)  # ucb is 0-d tensor

--- a/reagent/test/training/cb/test_deep_represent_linucb.py
+++ b/reagent/test/training/cb/test_deep_represent_linucb.py
@@ -1,0 +1,75 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import torch
+from reagent.core.types import CBInput
+from reagent.gym.policies.policy import Policy
+from reagent.gym.policies.samplers.discrete_sampler import GreedyActionSampler
+
+from reagent.models.deep_represent_linucb import DeepRepresentLinearRegressionUCB
+from reagent.models.fully_connected_network import FullyConnectedNetwork
+from reagent.training.cb.deep_represent_linucb_trainer import DeepRepresentLinUCBTrainer
+from reagent.training.parameters import LinUCBTrainerParameters
+
+
+class TestDeepRepresentLinUCB(unittest.TestCase):
+    def setUp(self):
+
+        self.params = LinUCBTrainerParameters()
+
+        raw_input_dim = 100
+        sizes = [100]
+        linucb_inp_dim = 100
+        activations = ["relu"]
+        output_activation = "linear"
+
+        customized_layers = FullyConnectedNetwork(
+            [raw_input_dim] + sizes + [linucb_inp_dim],
+            activations + [output_activation],
+            use_batch_norm=False,
+            dropout_ratio=0.0,
+            normalize_output=False,
+            use_layer_norm=False,
+        )
+        policy_network = DeepRepresentLinearRegressionUCB(
+            raw_input_dim=raw_input_dim,
+            sizes=sizes,
+            linucb_inp_dim=linucb_inp_dim,
+            activations=activations,
+            mlp_layers=customized_layers,
+        )
+
+        self.policy = Policy(scorer=policy_network, sampler=GreedyActionSampler())
+        self.trainer = DeepRepresentLinUCBTrainer(self.policy, **self.params.asdict())
+        self.batch = CBInput(
+            context_arm_features=torch.rand(2, 2, 100),
+            action=torch.tensor([[0], [1]], dtype=torch.long),
+            reward=torch.tensor([[1.5], [-2.3]]),
+        )  # random Gaussian features where feature_dim=100
+
+    def test_linucb_training_step(self):
+        self.trainer.training_step(self.batch, 0)
+        assert len(self.batch.action) == len(self.batch.reward)
+        assert len(self.batch.action) == self.batch.context_arm_features.shape[0]
+
+        loss_iterations = []
+        for _ in range(100):
+            # Linucb parameters are updated within training_step manually
+            loss = self.trainer.training_step(batch=self.batch, batch_idx=0).item()
+            loss_iterations.append(loss)
+
+        npt.assert_allclose(
+            np.asarray(loss_iterations[90:]),
+            np.zeros(10),
+            atol=1e-2,
+        )
+        return loss_iterations
+
+
+"""
+How to use:
+    test = TestDeepRepresentLinUCB()
+    test.setUp()
+    losses = test.test_linucb_training_step()
+"""

--- a/reagent/training/cb/deep_represent_linucb_trainer.py
+++ b/reagent/training/cb/deep_represent_linucb_trainer.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+import logging
+
+import torch
+from reagent.core.configuration import resolve_defaults
+from reagent.core.dataclasses import field
+from reagent.core.types import CBInput
+from reagent.gym.policies.policy import Policy
+from reagent.models.deep_represent_linucb import DeepRepresentLinearRegressionUCB
+from reagent.optimizer.union import Optimizer__Union
+from reagent.training.cb.linucb_trainer import _get_chosen_arm_features, LinUCBTrainer
+
+logger = logging.getLogger(__name__)
+
+
+class DeepRepresentLinUCBTrainer(LinUCBTrainer):
+    """
+    The trainer for a Contextual Bandit model, where deep represent layer serves as feature processor,
+    and then processed features are fed to LinUCB layer to produce UCB score.
+    This is extension of LinUCBTrainer. More details refer to docstring of LinUCBTrainer.
+
+    Reference:
+    - LinUCB : https://arxiv.org/pdf/2012.01780.pdf
+    - DeepRepresentLinUCB : https://arxiv.org/pdf/1003.0146.pdf
+    """
+
+    @resolve_defaults
+    def __init__(
+        self,
+        policy: Policy,
+        use_interaction_features: bool = False,
+        optimizer: Optimizer__Union = field(  # noqa: B008
+            default_factory=Optimizer__Union.default
+        ),
+    ):
+        super().__init__(
+            policy=policy,
+            use_interaction_features=use_interaction_features,
+        )
+        assert isinstance(
+            policy.scorer, DeepRepresentLinearRegressionUCB
+        ), "Trainer requires the policy scorer to be DeepRepresentLinearRegressionUCB"
+        self.scorer = policy.scorer
+        self.loss_fn = torch.nn.MSELoss(reduction="mean")
+        self.optimizer = optimizer
+
+    def configure_optimizers(self):
+        optimizers = []
+        optimizers.append(
+            self.optimizer.make_optimizer_scheduler(self.scorer.parameters())
+        )
+        return optimizers
+
+    def training_step(self, batch: CBInput, batch_idx: int, optimizer_idx: int = 0):
+        self._check_input(batch)
+        assert batch.action is not None  # to satisfy Pyre
+        assert batch.reward is not None  # to satisfy Pyre
+        x = _get_chosen_arm_features(batch.context_arm_features, batch.action)
+
+        pred_ucb = self.scorer(  # noqa
+            inp=x
+        )  # this calls scorer.forward() so as to update pred_u, and to grad descent on deep_represent module
+        loss = self.loss_fn(self.scorer.pred_u, batch.reward.t())
+
+        # update parameters
+        self.update_params(self.scorer.mlp_out.detach(), batch.reward, batch.weight)
+
+        return loss


### PR DESCRIPTION
Summary:
Implement Reagent DeepRepresentLinUCB.

It is a multiple layer regression model that output UCB score.
The first N layers are trainable by torch optimizer().
The last layer is the traditional LinUCB, and it is not updated by optimizer, but still will be updated by matrix computations.

Differential Revision: D38268001

