### PR TITLE
Reagent DeepRepresentLinucb [2/x] [quick fix nit]

### DIFF
--- a/reagent/training/cb/deep_represent_linucb_trainer.py
+++ b/reagent/training/cb/deep_represent_linucb_trainer.py
@@ -29,15 +29,14 @@ class DeepRepresentLinUCBTrainer(LinUCBTrainer):
     def __init__(
         self,
         policy: Policy,
-        use_interaction_features: bool = False,
-        automatic_optimization: bool = False,
         optimizer: Optimizer__Union = field(  # noqa: B008
             default_factory=Optimizer__Union.default
         ),
+        **kwargs,
     ):
         super().__init__(
             policy=policy,
-            use_interaction_features=use_interaction_features,
+            **kwargs,
         )
         assert isinstance(
             policy.scorer, DeepRepresentLinearRegressionUCB


### PR DESCRIPTION
Summary:
Previously if we do `super__init__(automatic_optimization=automatic_optimization)` (which we better do), the CI complains for some unknown reason.

This quick fix use `**kwargs` to include `automatic_optimization` .

Reviewed By: alexnikulkov

Differential Revision: D38771283

