### PR TITLE
Add upper limit on grpcio-tools version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,9 @@ license = BSD 3-Clause License
 packages = find:
 python_requires = >=3.8
 install_requires =
-  grpcio-tools>=1.44.0
+  # v1.48.0 and above upgraded the protobuf dependency, which lead to an error:
+  # https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly
+  grpcio-tools>=1.44.0,<1.48.0
   click>=7.0
   # ~=1.2.0 for compatibility with gym
   # issue: https://github.com/openai/spinningup/issues/178


### PR DESCRIPTION
Summary:
CircleCI tests started failing. Example: https://app.circleci.com/pipelines/github/facebookresearch/ReAgent/2490/workflows/efbceb68-9a01-4889-8d82-3d4167af4643/jobs/24780
Root cause is a significant jump in protobuf version from 3.19.4 to 4.21.5. This was caused by an an updated dependency on protobuf in grcpio-tools.
I'm adding an upper limit on grcpio-tools version to prevent this error

Differential Revision: D38870120

