### PR TITLE
Add dtype conversion to reagent CB batch preprocessor

### DIFF
--- a/reagent/models/deep_represent_linucb.py
+++ b/reagent/models/deep_represent_linucb.py
@@ -103,8 +103,6 @@ class DeepRepresentLinearRegressionUCB(LinearRegressionUCB):
 
         if ucb_alpha is None:
             ucb_alpha = self.ucb_alpha
-        if not (self.coefs_valid_for_A == self.A).all():
-            self._estimate_coefs()
         assert self.predict_ucb is True
         if self.predict_ucb:
             self.pred_u = torch.matmul(self.mlp_out, self.coefs)

--- a/reagent/preprocessing/transforms.py
+++ b/reagent/preprocessing/transforms.py
@@ -822,3 +822,18 @@ class Filter:
                 if k in new_data:
                     del new_data[k]
         return new_data
+
+
+class ToDtype:
+    """
+    Convert tensors to a specific dtype
+    """
+
+    def __init__(self, dtypes: Dict[str, torch.dtype]):
+        self.dtypes = dtypes
+
+    def __call__(self, data):
+        new_data = dict(data)
+        for key, dtype in self.dtypes.items():
+            new_data[key] = data[key].to(dtype=dtype)
+        return new_data

--- a/reagent/test/models/test_linear_regression_ucb.py
+++ b/reagent/test/models/test_linear_regression_ucb.py
@@ -27,7 +27,7 @@ class TestLinearRegressionUCB(unittest.TestCase):
     def test_call_no_ucb(self) -> None:
         x = torch.tensor([[1.0, 2.0], [1.0, 3.0]])  # y=x+1
         y = torch.tensor([3.0, 4.0])
-        model = LinearRegressionUCB(2, predict_ucb=False, l2_reg_lambda=0.0)
+        model = LinearRegressionUCB(2, ucb_alpha=0, l2_reg_lambda=0.0)
         trainer = LinUCBTrainer(Policy(scorer=model, sampler=GreedyActionSampler()))
         trainer.update_params(x, y)
 
@@ -41,7 +41,7 @@ class TestLinearRegressionUCB(unittest.TestCase):
     def test_call_ucb(self) -> None:
         x = torch.tensor([[1.0, 2.0], [1.0, 3.0]])  # y=x+1
         y = torch.tensor([3.0, 4.0])
-        model = LinearRegressionUCB(2, predict_ucb=True, l2_reg_lambda=0.0)
+        model = LinearRegressionUCB(2, l2_reg_lambda=0.0)
         trainer = LinUCBTrainer(Policy(scorer=model, sampler=GreedyActionSampler()))
         trainer.update_params(x, y)
 

--- a/reagent/test/preprocessing/test_transforms.py
+++ b/reagent/test/preprocessing/test_transforms.py
@@ -746,3 +746,22 @@ class TestTransforms(unittest.TestCase):
         broadcasted_tensors = transforms._broadcast_tensors_for_cat(tensors, 0)
         self.assertEqual(tuple(broadcasted_tensors[0].shape), (1, 3, 5, 4))
         self.assertEqual(tuple(broadcasted_tensors[1].shape), (10, 3, 5, 4))
+
+    def test_ToDtype(self) -> None:
+        data = {
+            "a": torch.tensor([[9.0, 4.5], [3.4, 3.9]]).float(),
+            "b": torch.tensor([[9.2, 2.5], [4.4, 1.9]]).double(),
+            "c": torch.tensor([[9.1, 2.3], [4.2, 1.4]]).double(),
+        }
+        t = transforms.ToDtype({"b": torch.float})
+        t_data = t(data)
+
+        # make sure all values was left unmodified
+        self.assertTorchTensorEqual(data["a"], t_data["a"])
+        self.assertTorchTensorEqual(data["b"], t_data["b"])
+        self.assertTorchTensorEqual(data["c"], t_data["c"])
+
+        # mase sure the data types are correct
+        self.assertEqual(t_data["a"].dtype, torch.float)  # was float, didn't change
+        self.assertEqual(t_data["b"].dtype, torch.float)  # changed from double to float
+        self.assertEqual(t_data["c"].dtype, torch.double)  # was double, didn't change

--- a/reagent/test/training/cb/test_linucb.py
+++ b/reagent/test/training/cb/test_linucb.py
@@ -109,7 +109,7 @@ class TestLinUCB(unittest.TestCase):
             scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-5
         )
 
-        scorer._estimate_coefs()
+        scorer._calculate_coefs()
         npt.assert_equal(scorer.A.numpy(), scorer.coefs_valid_for_A.numpy())
 
         npt.assert_allclose(

--- a/reagent/test/training/cb/test_linucb.py
+++ b/reagent/test/training/cb/test_linucb.py
@@ -104,7 +104,7 @@ class TestLinUCB(unittest.TestCase):
             self.batch.context_arm_features, self.batch.action
         ).numpy()
 
-        npt.assert_allclose(scorer.A.numpy(), np.eye(self.x_dim) + x.T @ x, rtol=1e-5)
+        npt.assert_allclose(scorer.A.numpy(), x.T @ x, rtol=1e-5)
         npt.assert_allclose(
             scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-5
         )

--- a/reagent/training/cb/linucb_trainer.py
+++ b/reagent/training/cb/linucb_trainer.py
@@ -90,6 +90,7 @@ class LinUCBTrainer(ReAgentLightningModule):
 
         self.scorer.A += torch.matmul(x.t(), x * weight)  # dim (DA*DC, DA*DC)
         self.scorer.b += torch.matmul(x.t(), y * weight).squeeze()  # dim (DA*DC,)
+        self.scorer.num_obs += y.shape[0]
 
     def _check_input(self, batch: CBInput):
         assert batch.context_arm_features.ndim == 3
@@ -106,3 +107,8 @@ class LinUCBTrainer(ReAgentLightningModule):
         # update parameters
         assert batch.reward is not None  # to satisfy Pyre
         self.update_params(x, batch.reward, batch.weight)
+
+    def on_train_epoch_end(self):
+        super().on_train_epoch_end()
+        # at the end of the training epoch calculate the coefficients
+        self.scorer._calculate_coefs()


### PR DESCRIPTION
Summary:
Add dtype conversion to reagent CB batch preprocessor
Without this some elements were `double` instead of `float`

Reviewed By: czxttkl

Differential Revision: D38807573

