### PR TITLE
Add support for distributed training to LinUCB

### DIFF
--- a/reagent/models/deep_represent_linucb.py
+++ b/reagent/models/deep_represent_linucb.py
@@ -103,8 +103,6 @@ class DeepRepresentLinearRegressionUCB(LinearRegressionUCB):
 
         if ucb_alpha is None:
             ucb_alpha = self.ucb_alpha
-        if not (self.coefs_valid_for_A == self.A).all():
-            self._estimate_coefs()
         assert self.predict_ucb is True
         if self.predict_ucb:
             self.pred_u = torch.matmul(self.mlp_out, self.coefs)

--- a/reagent/test/models/test_linear_regression_ucb.py
+++ b/reagent/test/models/test_linear_regression_ucb.py
@@ -27,7 +27,7 @@ class TestLinearRegressionUCB(unittest.TestCase):
     def test_call_no_ucb(self) -> None:
         x = torch.tensor([[1.0, 2.0], [1.0, 3.0]])  # y=x+1
         y = torch.tensor([3.0, 4.0])
-        model = LinearRegressionUCB(2, predict_ucb=False, l2_reg_lambda=0.0)
+        model = LinearRegressionUCB(2, ucb_alpha=0, l2_reg_lambda=0.0)
         trainer = LinUCBTrainer(Policy(scorer=model, sampler=GreedyActionSampler()))
         trainer.update_params(x, y)
 
@@ -41,7 +41,7 @@ class TestLinearRegressionUCB(unittest.TestCase):
     def test_call_ucb(self) -> None:
         x = torch.tensor([[1.0, 2.0], [1.0, 3.0]])  # y=x+1
         y = torch.tensor([3.0, 4.0])
-        model = LinearRegressionUCB(2, predict_ucb=True, l2_reg_lambda=0.0)
+        model = LinearRegressionUCB(2, l2_reg_lambda=0.0)
         trainer = LinUCBTrainer(Policy(scorer=model, sampler=GreedyActionSampler()))
         trainer.update_params(x, y)
 

--- a/reagent/test/models/test_linear_regression_ucb.py
+++ b/reagent/test/models/test_linear_regression_ucb.py
@@ -36,7 +36,7 @@ class TestLinearRegressionUCB(unittest.TestCase):
 
         self.assertIsInstance(out, torch.Tensor)
         self.assertEqual(tuple(out.shape), (2,))
-        npt.assert_allclose(out.numpy(), np.array([6.0, 7.0]), rtol=1e-5)
+        npt.assert_allclose(out.numpy(), np.array([6.0, 7.0]), rtol=1e-4)
 
     def test_call_ucb(self) -> None:
         x = torch.tensor([[1.0, 2.0], [1.0, 3.0]])  # y=x+1
@@ -59,4 +59,4 @@ class TestLinearRegressionUCB(unittest.TestCase):
 
         self.assertIsInstance(out, torch.Tensor)
         self.assertEqual(tuple(out.shape), (2,))
-        npt.assert_allclose(out.numpy(), expected_out, rtol=1e-6)
+        npt.assert_allclose(out.numpy(), expected_out, rtol=1e-4)

--- a/reagent/test/training/cb/test_linucb.py
+++ b/reagent/test/training/cb/test_linucb.py
@@ -104,16 +104,19 @@ class TestLinUCB(unittest.TestCase):
             self.batch.context_arm_features, self.batch.action
         ).numpy()
 
-        npt.assert_allclose(scorer.A.numpy(), np.eye(self.x_dim) + x.T @ x, rtol=1e-5)
+        npt.assert_allclose(scorer.A.numpy(), x.T @ x, rtol=1e-4)
         npt.assert_allclose(
-            scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-5
+            scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-4
         )
 
         scorer._calculate_coefs()
         npt.assert_equal(scorer.A.numpy(), scorer.coefs_valid_for_A.numpy())
 
         npt.assert_allclose(
-            scorer.A.numpy() @ scorer.inv_A.numpy(), np.eye(self.x_dim), atol=1e-3
+            (np.eye(self.x_dim) * scorer.l2_reg_lambda + scorer.A.numpy())
+            @ scorer.inv_A.numpy(),
+            np.eye(self.x_dim),
+            atol=1e-3,
         )
 
     def test_linucb_weights(self):
@@ -135,5 +138,5 @@ class TestLinUCB(unittest.TestCase):
         npt.assert_array_less(
             np.zeros(scorer_1.A.shape), scorer_1.A.numpy()
         )  # make sure A got updated
-        npt.assert_allclose(scorer_1.A.numpy(), scorer_2.A.numpy(), rtol=1e-6)
-        npt.assert_allclose(scorer_1.b.numpy(), scorer_2.b.numpy(), rtol=1e-6)
+        npt.assert_allclose(scorer_1.A.numpy(), scorer_2.A.numpy(), rtol=1e-4)
+        npt.assert_allclose(scorer_1.b.numpy(), scorer_2.b.numpy(), rtol=1e-4)

--- a/reagent/test/training/cb/test_linucb.py
+++ b/reagent/test/training/cb/test_linucb.py
@@ -109,7 +109,7 @@ class TestLinUCB(unittest.TestCase):
             scorer.b.numpy(), x.T @ self.batch.reward.squeeze().numpy(), rtol=1e-5
         )
 
-        scorer._estimate_coefs()
+        scorer._calculate_coefs()
         npt.assert_equal(scorer.A.numpy(), scorer.coefs_valid_for_A.numpy())
 
         npt.assert_allclose(

--- a/reagent/training/cb/linucb_trainer.py
+++ b/reagent/training/cb/linucb_trainer.py
@@ -90,6 +90,7 @@ class LinUCBTrainer(ReAgentLightningModule):
 
         self.scorer.A += torch.matmul(x.t(), x * weight)  # dim (DA*DC, DA*DC)
         self.scorer.b += torch.matmul(x.t(), y * weight).squeeze()  # dim (DA*DC,)
+        self.scorer.num_obs += y.shape[0]
 
     def _check_input(self, batch: CBInput):
         assert batch.context_arm_features.ndim == 3
@@ -106,3 +107,8 @@ class LinUCBTrainer(ReAgentLightningModule):
         # update parameters
         assert batch.reward is not None  # to satisfy Pyre
         self.update_params(x, batch.reward, batch.weight)
+
+    def on_train_epoch_end(self):
+        super().on_train_epoch_end()
+        # at the end of the training epoch calculate the coefficients
+        self.scorer._calculate_coefs()


### PR DESCRIPTION
Summary:
Enable distributed training by reducing the values of `A` and `b` across all trainer instances.
For non-distributed training nothing changes because `sync_ddp_if_available` returns the input if distributed training isn't used

Differential Revision: D38294567

