### PR TITLE
Only try to getattr if hasattr

### DIFF
--- a/reagent/optimizer/optimizer.py
+++ b/reagent/optimizer/optimizer.py
@@ -72,7 +72,7 @@ class OptimizerConfig(metaclass=RegistryMeta):
         filtered_args = {
             k: getattr(self, k)
             for k in inspect.signature(torch_optimizer_class).parameters
-            if k != "params"
+            if k != "params" and hasattr(self, k)
         }
         optimizer = torch_optimizer_class(params=params, **filtered_args)
         if len(self.lr_schedulers) == 0:


### PR DESCRIPTION
Summary:
Follow up to https://fb.workplace.com/groups/1013818346200497/posts/1141315933450737

To avoid test failures like
```
ERROR: test_configure_optimizers (reagent.test.training.test_qrdqn.TestQRDQN)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/buck-out/dev/gen/reagent/training_tests#binary,link-tree/reagent/test/training/test_qrdqn.py", line 179, in test_configure_optimizers
    optimizers = trainer.configure_optimizers()
  File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/buck-out/dev/gen/reagent/training_tests#binary,link-tree/reagent/training/qrdqn_trainer.py", line 84, in configure_optimizers
    self.q_network_optimizer.make_optimizer_scheduler(
  File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/buck-out/dev/gen/reagent/training_tests#binary,link-tree/reagent/optimizer/union.py", line 62, in make_optimizer_scheduler
    return self.value.make_optimizer_scheduler(params)
  File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/buck-out/dev/gen/reagent/training_tests#binary,link-tree/reagent/optimizer/optimizer.py", line 72, in make_optimizer_scheduler
    filtered_args = {
  File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/buck-out/dev/gen/reagent/training_tests#binary,link-tree/reagent/optimizer/optimizer.py", line 73, in <dictcomp>
    k: getattr(self, k)
AttributeError: 'Adam' object has no attribute 'fused'
```

Differential Revision: D39750850

