### PR TITLE
Fix Multi-processor in LinUCB training

### DIFF
--- a/reagent/test/training/cb/test_disjoint_linucb.py
+++ b/reagent/test/training/cb/test_disjoint_linucb.py
@@ -82,7 +82,9 @@ class TestDisjointLinUCB(unittest.TestCase):
 
         trainer_1.training_step(obss[0], 0)
         trainer_1.training_step(obss[1], 1)
+        trainer_1.on_train_epoch_end()
         trainer_2.training_step(self.batch, 0)
+        trainer_2.on_train_epoch_end()
 
         for arm in range(self.num_arms):
             npt.assert_array_less(
@@ -104,6 +106,7 @@ class TestDisjointLinUCB(unittest.TestCase):
         policy = Policy(scorer=scorer, sampler=GreedyActionSampler())
         trainer = DisjointLinUCBTrainer(policy)
         trainer.training_step(self.batch, 0)
+        trainer.on_train_epoch_end()
         # the feature matrix (computed by hand)
         for arm in range(self.num_arms):
             x = self.batch[arm].context_arm_features.numpy()
@@ -114,7 +117,6 @@ class TestDisjointLinUCB(unittest.TestCase):
                 rtol=1e-5,
             )
 
-        scorer._estimate_coefs()
         for arm in range(self.num_arms):
             npt.assert_allclose(
                 (np.eye(self.x_dim) + scorer.A[arm].numpy())
@@ -140,8 +142,10 @@ class TestDisjointLinUCB(unittest.TestCase):
         trainer_2 = DisjointLinUCBTrainer(policy_2)
 
         trainer_1.training_step(batch_with_weight, 0)
+        trainer_1.on_train_epoch_end()
         for i in range(3):
             trainer_2.training_step(self.batch, i)
+        trainer_2.on_train_epoch_end()
 
         for arm in range(self.num_arms):
             npt.assert_array_less(


### PR DESCRIPTION
Summary:
1. We train LinUCB models on two hours (7am and 8am) separately and get covariance matrixes A1 and A2 for each.
2. We train a LinUCB model at 7am, enable recurring so it launched a recurring training at 8am. Then we get covariance matrix A.

We found that A is around 8*A1 + A2 instead of A1 + A2, where we used NPROC_PER_NODE = 8 when training.

The reason is the following:

Current implementation aggregates A and b calculated in each training processor. However, if we do recurring training, then in the 2nd training child, it will aggregate the previous A NPROC_PER_NODE times and then add the new A aggregated from current epoch.

This diff fixes the above issue.

Reviewed By: alexnikulkov

Differential Revision: D39902734

