### PR TITLE
Delete stub file to enable mypy check (#4649)

### DIFF
--- a/reagent/models/seq2slate.py
+++ b/reagent/models/seq2slate.py
@@ -960,8 +960,6 @@ class _DistributedSeq2SlateNet(ModelBase):
 
         current_device = torch.cuda.current_device()
         self.data_parallel = DistributedDataParallel(
-            # pyre-fixme[6]: For 1st param expected `Module` but got `Union[Module,
-            #  Tensor]`.
             seq2slate_net.seq2slate,
             device_ids=[current_device],
             output_device=current_device,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/detectron2/pull/4649

Context in https://fburl.com/4irjskbe

This change deletes distributed.pyi, so that lintrunner will run mypy on distributed.py for typing check.

Differential Revision: D41028360

