### PR TITLE
Fix reagent LRScheduler tests

### DIFF
--- a/reagent/optimizer/utils.py
+++ b/reagent/optimizer/utils.py
@@ -17,4 +17,6 @@ def is_torch_optimizer(cls):
 
 
 def is_torch_lr_scheduler(cls):
-    return is_strict_subclass(cls, torch.optim.lr_scheduler._LRScheduler)
+    return is_strict_subclass(
+        cls, torch.optim.lr_scheduler._LRScheduler
+    ) or is_strict_subclass(cls, torch.optim.lr_scheduler.LRScheduler)


### PR DESCRIPTION
Summary:
I recently exposed LRScheduler as a public endpoint as that is the right direction for users. This diff adds LRScheduler as a torch lr scheduler, which it is.

Would fix test errors such as https://www.internalfb.com/intern/testinfra/diagnostics/281475249445597.562950030008200.1668085134/, which were introduced by my landing of D41109279.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: czxttkl

Differential Revision: D41187073

