### PR TITLE
add support for variable number of arms to FbContBanditBatchPreprocessor

### DIFF
--- a/reagent/core/types.py
+++ b/reagent/core/types.py
@@ -1114,6 +1114,7 @@ class FrechetSortConfig:
 @dataclass
 class CBInput(TensorDataClass):
     context_arm_features: torch.Tensor
+    arm_presence: Final[Optional[torch.Tensor]] = None
     action: Final[Optional[torch.Tensor]] = None
     reward: Final[Optional[torch.Tensor]] = None
     log_prob: Final[Optional[torch.Tensor]] = None
@@ -1137,6 +1138,7 @@ class CBInput(TensorDataClass):
     def from_dict(cls, d: Dict[str, torch.Tensor]) -> "CBInput":
         return cls(
             context_arm_features=d["context_arm_features"],
+            arm_presence=d.get("arm_presence", None),
             action=d.get("action", None),
             reward=d.get("reward", None),
             log_prob=d.get("log_prob", None),

--- a/reagent/preprocessing/types.py
+++ b/reagent/preprocessing/types.py
@@ -47,3 +47,4 @@ class InputColumn(object):
     ARM_FEATURES = "arm_features"
     CONTEXT_ARM_FEATURES = "context_arm_features"
     ARMS = "arms"
+    ARM_PRESENCE = "arm_presence"


### PR DESCRIPTION
Summary:
Make changes to reagent transforms and CB preprocessor to add support for variable number of arms
1. The main API change is that `num_arms=None` in `FbContBanditBatchPreprocessor`, then we use variable-length version of the code.
A presence tensor is generated to indicate which arms are present vs 0-padded
2. Add `arm_presence` field to `CBInput` to indicate which arms are present

Differential Revision: D41989361

