### PR TITLE
Track average A and b instead of cumulative in LinUCB

### DIFF
--- a/reagent/models/deep_represent_linucb.py
+++ b/reagent/models/deep_represent_linucb.py
@@ -104,7 +104,10 @@ class DeepRepresentLinearRegressionUCB(LinearRegressionUCB):
             ucb_alpha = self.ucb_alpha
         self.pred_u = torch.matmul(self.mlp_out, self.coefs)
         if ucb_alpha != 0:
-            self.pred_sigma = torch.sqrt(batch_quadratic_form(self.mlp_out, self.inv_A))
+            self.pred_sigma = torch.sqrt(
+                batch_quadratic_form(self.mlp_out, self.inv_avg_A)
+                / torch.clamp(self.sum_weight, min=0.00001)
+            )
             pred_ucb = self.pred_u + ucb_alpha * self.pred_sigma
         else:
             pred_ucb = self.pred_u

--- a/reagent/test/evaluation/cb/test_integration.py
+++ b/reagent/test/evaluation/cb/test_integration.py
@@ -81,21 +81,27 @@ class TestEvalDuringTraining(unittest.TestCase):
         # check if trained model state is correct
         batch_1_used_features = batch_1.context_arm_features[1, 1].numpy()
         npt.assert_allclose(
-            self.trainer.scorer.A.numpy(),
+            (self.trainer.scorer.avg_A * self.trainer.scorer.sum_weight).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features),
         )
         npt.assert_allclose(
-            self.trainer.scorer.b.numpy(),
+            (self.trainer.scorer.avg_b * self.trainer.scorer.sum_weight).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item(),
         )
 
         # check if evaluated model state is correct (should be same as trained model)
         npt.assert_allclose(
-            self.eval_module.eval_model.A.numpy(),
+            (
+                self.eval_module.eval_model.avg_A
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features),
         )
         npt.assert_allclose(
-            self.eval_module.eval_model.b.numpy(),
+            (
+                self.eval_module.eval_model.avg_b
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item(),
         )
 
@@ -132,23 +138,29 @@ class TestEvalDuringTraining(unittest.TestCase):
         # check that trained model state is correct
         batch_2_used_features = batch_2.context_arm_features[0, 1].numpy()
         npt.assert_allclose(
-            self.trainer.scorer.A.numpy(),
+            (self.trainer.scorer.avg_A * self.trainer.scorer.sum_weight).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features)
             + np.outer(batch_2_used_features, batch_2_used_features),
         )
         npt.assert_allclose(
-            self.trainer.scorer.b.numpy(),
+            (self.trainer.scorer.avg_b * self.trainer.scorer.sum_weight).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item()
             + batch_2_used_features * batch_2.reward[0, 0].item(),
         )
 
         # check that evaluated model state is correct (same as it was after batch_1)
         npt.assert_allclose(
-            self.eval_module.eval_model.A.numpy(),
+            (
+                self.eval_module.eval_model.avg_A
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features),
         )
         npt.assert_allclose(
-            self.eval_module.eval_model.b.numpy(),
+            (
+                self.eval_module.eval_model.avg_b
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item(),
         )
 
@@ -204,13 +216,13 @@ class TestEvalDuringTraining(unittest.TestCase):
         # check that trained model state is correct
         batch_3_used_features = batch_3.context_arm_features[1, 1].numpy()
         npt.assert_allclose(
-            self.trainer.scorer.A.numpy(),
+            (self.trainer.scorer.avg_A * self.trainer.scorer.sum_weight).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features)
             + np.outer(batch_2_used_features, batch_2_used_features)
             + np.outer(batch_3_used_features, batch_3_used_features),
         )
         npt.assert_allclose(
-            self.trainer.scorer.b.numpy(),
+            (self.trainer.scorer.avg_b * self.trainer.scorer.sum_weight).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item()
             + batch_2_used_features * batch_2.reward[0, 0].item()
             + batch_3_used_features * batch_3.reward[1, 0].item(),
@@ -218,11 +230,17 @@ class TestEvalDuringTraining(unittest.TestCase):
 
         # check that evaluated model state is correct (same as it was after batch_1)
         npt.assert_allclose(
-            self.eval_module.eval_model.A.numpy(),
+            (
+                self.eval_module.eval_model.avg_A
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             np.outer(batch_1_used_features, batch_1_used_features),
         )
         npt.assert_allclose(
-            self.eval_module.eval_model.b.numpy(),
+            (
+                self.eval_module.eval_model.avg_b
+                * self.eval_module.eval_model.sum_weight
+            ).numpy(),
             batch_1_used_features * batch_1.reward[1, 0].item(),
         )
 

--- a/reagent/test/evaluation/cb/test_policy_evaluator.py
+++ b/reagent/test/evaluation/cb/test_policy_evaluator.py
@@ -100,9 +100,9 @@ class TestPolicyEvaluator(unittest.TestCase):
 
     def test_update_eval_model(self):
         policy_network_1 = LinearRegressionUCB(2)
-        policy_network_1.A += 0.3
+        policy_network_1.avg_A += 0.3
         policy_network_2 = LinearRegressionUCB(2)
-        policy_network_2.A += 0.1
+        policy_network_2.avg_A += 0.1
         eval_module = PolicyEvaluator(policy_network_1)
         self.assertTrue(
             _compare_state_dicts(
@@ -119,7 +119,7 @@ class TestPolicyEvaluator(unittest.TestCase):
 
         # change to the source model shouldn't affect the model in the eval module
         original_state_dict_2 = copy.deepcopy(policy_network_2.state_dict())
-        policy_network_2.A += 0.4
+        policy_network_2.avg_A += 0.4
         self.assertTrue(
             _compare_state_dicts(
                 eval_module.eval_model.state_dict(), original_state_dict_2

--- a/reagent/test/models/test_linear_regression_ucb.py
+++ b/reagent/test/models/test_linear_regression_ucb.py
@@ -61,10 +61,14 @@ class TestLinearRegressionUCB(unittest.TestCase):
 
         expected_out = np.zeros(2)
         expected_out[0] = 6.0 + alpha * np.sqrt(
-            inp[0].numpy() @ model.inv_A.numpy() @ inp[0].numpy()
+            inp[0].numpy()
+            @ (model.inv_avg_A / model.sum_weight).numpy()
+            @ inp[0].numpy()
         )
         expected_out[1] = 7.0 + alpha * np.sqrt(
-            inp[1].numpy() @ model.inv_A.numpy() @ inp[1].numpy()
+            inp[1].numpy()
+            @ (model.inv_avg_A / model.sum_weight).numpy()
+            @ inp[1].numpy()
         )
 
         self.assertIsInstance(out, torch.Tensor)


### PR DESCRIPTION
Summary:
I'm updating the training logic of LinUCB to keep track of the average values of `A` and `b` instead of cumulative values. This should improve the numerical stability of training by preventing numerical overflows.

The average values are aggregated among the trainers and among epochs when computing the coefficients.

Differential Revision: D42334470

