### PR TITLE
add support for distributed Offline Eval

### DIFF
--- a/reagent/evaluation/cb/policy_evaluator.py
+++ b/reagent/evaluation/cb/policy_evaluator.py
@@ -1,6 +1,12 @@
+import logging
+
 import torch
+from pytorch_lightning.utilities.distributed import ReduceOp, sync_ddp_if_available
 from reagent.core.types import CBInput
 from reagent.evaluation.cb.base_evaluator import BaseOfflineEval
+
+
+logger = logging.getLogger(__name__)
 
 
 EPSILON = 1e-9
@@ -11,18 +17,22 @@ class PolicyEvaluator(BaseOfflineEval):
     An offline evaluator for Contextual Bandits, based on the paper https://arxiv.org/pdf/1003.0146.pdf (Algorithm 3)
     """
 
-    avg_reward_weighted: torch.Tensor
+    sum_reward_weighted: torch.Tensor
+    sum_reward_weighted_local: torch.Tensor
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.register_buffer("avg_reward_weighted", torch.zeros(1, dtype=torch.float))
+        self.register_buffer("sum_reward_weighted", torch.zeros(1, dtype=torch.float))
+        self.register_buffer(
+            "sum_reward_weighted_local", torch.zeros(1, dtype=torch.float)
+        )
 
     @torch.no_grad()
     def _process_all_data(self, batch: CBInput) -> None:
         if batch.weight is not None:
-            self.all_data_sum_weight += batch.weight.sum()
+            self.all_data_sum_weight_local += batch.weight.sum()
         else:
-            self.all_data_sum_weight += len(batch)
+            self.all_data_sum_weight_local += len(batch)
 
     @torch.no_grad()
     def _process_used_data(self, batch: CBInput) -> None:
@@ -33,13 +43,30 @@ class PolicyEvaluator(BaseOfflineEval):
         """
         assert batch.reward is not None
         assert batch.weight is not None
-        batch_sum_weight = batch.weight.sum()
         assert batch.weight.shape == batch.reward.shape
-        self.avg_reward_weighted = (
-            self.avg_reward_weighted * self.sum_weight
-            + (batch.weight * batch.reward).sum()
-        ) / (self.sum_weight + batch_sum_weight + EPSILON)
-        self.sum_weight += batch_sum_weight
+        self.sum_reward_weighted_local += (batch.weight * batch.reward).sum()
+        self.sum_weight_local += batch.weight.sum()
+
+    def _aggregate_across_instances(self) -> None:
+        # sum local values across all trainers, add to the global value
+        # clone the tensors to avoid modifying them inplace
+        self.sum_reward_weighted += sync_ddp_if_available(
+            self.sum_reward_weighted_local.clone(), reduce_op=ReduceOp.SUM
+        )
+        self.sum_weight += sync_ddp_if_available(
+            self.sum_weight_local.clone(), reduce_op=ReduceOp.SUM
+        )
+        self.all_data_sum_weight += sync_ddp_if_available(
+            self.all_data_sum_weight_local.clone(), reduce_op=ReduceOp.SUM
+        )
+        # reset local values to zero
+        self.sum_reward_weighted_local.zero_()
+        self.sum_weight_local.zero_()
+        self.all_data_sum_weight_local.zero_()
 
     def get_avg_reward(self) -> float:
-        return self.avg_reward_weighted.item()
+        assert (
+            self.sum_weight_local.item() == 0.0
+        ), f"Non-zero local weight {self.sum_weight_local.item()} in the evaluator. _aggregate_across_instances() Should have beed called to aggregate across all instances and zero-out the local values."
+        # return the average reward
+        return (self.sum_reward_weighted / (self.sum_weight + EPSILON)).item()

--- a/reagent/test/evaluation/cb/test_integration.py
+++ b/reagent/test/evaluation/cb/test_integration.py
@@ -258,7 +258,11 @@ class TestEvalDuringTraining(unittest.TestCase):
         )
 
         # check total weight (number of observations). Should be 3
-        self.assertAlmostEqual(self.eval_module.sum_weight.item(), 3.0, places=4)
+        self.assertAlmostEqual(
+            (self.eval_module.sum_weight + self.eval_module.sum_weight_local).item(),
+            3.0,
+            places=4,
+        )
 
         # metrics should have been logged once, at the end of epoch
         # TODO: test logging logic triggered by eval_model_update_critical_weight


### PR DESCRIPTION
Summary:
Adding support for distributed Offline Eval. This requires maintaining local buffers in each trainer instance and syncing them across all trainers periodically. The sync happens under one of 2 conditions:
1. When the "critical" weight of data has been consumed (will be set approximately equal to the size of 1-hr partition)
2. At the end of the training epoch (if data has been consumed since last sync)

Also, updating the FREE pipeline to remove the restriction on number of nodes for Offline Eval runs

Differential Revision: D42407669

